### PR TITLE
Add TCP and UDP servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,15 @@ Planned features
 - support for sending queries to specific servers based on domain
 - dynamic configuration updates
 - extra records (e.g. from /etc/hosts)
+
+## Simple usage
+
+```sh
+make
+./_build/bin/main.native doc/example.config
+```
+and then send queries as follows:
+```
+dig @127.0.0.1 -p 5555 www.google.com
+dig @127.0.0.1 -p 5555 www.docker.com
+```

--- a/_tags
+++ b/_tags
@@ -1,7 +1,7 @@
 true : bin_annot, safe_string
 true: warn_error(+1..49), warn(A-3-4-41-44)
 true: package(bytes lwt astring logs result cstruct fmt rresult ipaddr)
-true: package(dns mirage-flow)
+true: package(dns mirage-flow cstruct.lwt)
 
 <bin>: include
 <lib>: include

--- a/_tags
+++ b/_tags
@@ -1,6 +1,7 @@
 true : bin_annot, safe_string
 true: warn_error(+1..49), warn(A-3-4-41-44)
-true: package(bytes lwt astring logs result cstruct fmt rresult ipaddr mirage-flow)
+true: package(bytes lwt astring logs result cstruct fmt rresult ipaddr)
+true: package(dns mirage-flow)
 
 <bin>: include
 <lib>: include

--- a/doc/example.config
+++ b/doc/example.config
@@ -1,3 +1,3 @@
-(((zones (corp.docker.com docker.com))
-   (address ((ip (V4 127.0.0.1)) (port 53))))
-  ((zones ()) (address ((ip (V4 127.0.0.1)) (port 53)))))
+(((zones ((corp docker com) (docker com)))
+   (address ((ip (V4 8.8.4.4)) (port 53))))
+  ((zones ()) (address ((ip (V4 8.8.8.8)) (port 53)))))

--- a/lib/dns_forward.ml
+++ b/lib/dns_forward.ml
@@ -14,3 +14,12 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
  *)
+
+module Make(Tcpip: Dns_forward_s.TCPIP) = struct
+
+  type t = unit
+
+  let make _config =
+    ()
+
+end

--- a/lib/dns_forward.ml
+++ b/lib/dns_forward.ml
@@ -15,11 +15,70 @@
  *
  *)
 
+let src =
+  let src = Logs.Src.create "Dns_forward" ~doc:"DNS forwarding" in
+  Logs.Src.set_level src (Some Logs.Debug);
+  src
+
+module Log = (val Logs.src_log src : Logs.LOG)
+
+
+let is_in_domain name domain =
+  let name' = List.length name and domain' = List.length domain in
+  name' >= domain' && begin
+    let to_remove = name' - domain' in
+    let rec trim n xs = match n, xs with
+      | 0, _ -> xs
+      | _, [] -> invalid_arg "trim"
+      | n, _ :: xs -> trim (n - 1) xs in
+    let trimmed_name = trim to_remove name in
+    trimmed_name = domain
+  end
+
+let choose_servers config request =
+  let open Dns.Packet in
+  let open Dns_forward_config in
+  (* Match the name in the query against the configuration *)
+  begin match request with
+  | { questions = [ { q_name; _ } ]; _ } ->
+    let labels = Dns.Name.to_string_list q_name in
+    let matching_servers = List.filter (fun server ->
+      List.fold_left (||) false @@ List.map (is_in_domain labels) server.zones
+    ) config in
+    begin match matching_servers with
+    | _ :: _ ->
+      (* If any of the configured domains match, send to these servers *)
+      matching_servers
+    | [] ->
+      (* Otherwise send to all servers with no match *)
+      List.filter (fun server -> server.zones = []) config
+    end
+  | _ -> []
+  end
+
 module Make(Tcpip: Dns_forward_s.TCPIP) = struct
 
-  type t = unit
+  type t = {
+    config: Dns_forward_config.t;
+  }
 
-  let make _config =
-    ()
+  let make config =
+    { config }
 
+  let answer t buffer =
+    let len = Cstruct.len buffer in
+    let buf = Dns.Buf.of_cstruct buffer in
+    match Dns.Protocol.Server.parse (Dns.Buf.sub buf 0 len) with
+    | Some request ->
+      let servers = choose_servers t.config request in
+      (* send the request to all upstream servers *)
+      let ts = List.map (fun server ->
+        let open Dns_forward_config in
+        Log.debug (fun f -> f "forwarding to server %s:%d" (Ipaddr.to_string server.address.ip) server.address.port);
+        Lwt.return_unit
+      ) servers in
+      Lwt.join ts
+    | None ->
+      Log.debug (fun f -> f "failed to parse request");
+      Lwt.return_unit
 end

--- a/lib/dns_forward.mli
+++ b/lib/dns_forward.mli
@@ -14,3 +14,13 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
  *)
+
+ module Make(Tcpip: Dns_forward_s.TCPIP): sig
+
+  type t
+  (** A forwarding DNS proxy *)
+
+  val make: Dns_forward_config.t -> t
+  (** Construct a forwarding DNS proxy given some configuration *)
+
+ end

--- a/lib/dns_forward.mli
+++ b/lib/dns_forward.mli
@@ -15,7 +15,7 @@
  *
  *)
 
- module Make(Tcpip: Dns_forward_s.TCPIP): sig
+ module Make(Tcpip: Dns_forward_s.TCPIP)(Time: V1_LWT.TIME): sig
 
   type t
   (** A forwarding DNS proxy *)
@@ -23,7 +23,7 @@
   val make: Dns_forward_config.t -> t
   (** Construct a forwarding DNS proxy given some configuration *)
 
-  val answer: t -> Cstruct.t -> unit Lwt.t
+  val answer: t -> Cstruct.t -> Cstruct.t option Lwt.t
   (** Given a DNS request, construct an response *)
 
  end

--- a/lib/dns_forward.mli
+++ b/lib/dns_forward.mli
@@ -23,4 +23,7 @@
   val make: Dns_forward_config.t -> t
   (** Construct a forwarding DNS proxy given some configuration *)
 
+  val answer: t -> Cstruct.t -> unit Lwt.t
+  (** Given a DNS request, construct an response *)
+
  end

--- a/lib/dns_forward_config.ml
+++ b/lib/dns_forward_config.ml
@@ -21,7 +21,7 @@ type address = {
   port: int;
 } [@@deriving sexp]
 
-type domain = string [@@deriving sexp]
+type domain = string list [@@deriving sexp]
 
 type server = {
   zones: domain list;

--- a/lib/dns_forward_config.mli
+++ b/lib/dns_forward_config.mli
@@ -20,7 +20,7 @@ type address = {
   port: int;
 }
 
-type domain = string
+type domain = string list
 
 type server = {
   zones: domain list; (** use this server for these specific domains *)

--- a/lib/dns_forward_lwt_unix.ml
+++ b/lib/dns_forward_lwt_unix.ml
@@ -45,7 +45,19 @@ module Common = struct
   let sockaddr_of_address (dst, dst_port) =
     Unix.ADDR_INET(Unix.inet_addr_of_string @@ Ipaddr.to_string dst, dst_port)
 
+  let string_of_address (dst, dst_port) =
+    Ipaddr.to_string dst ^ ":" ^ (string_of_int dst_port)
+
   type 'a io = 'a Lwt.t
+
+  let getsockname fn_name fd_opt = match fd_opt with
+    | None -> failwith (fn_name ^ ": socket is closed")
+    | Some fd ->
+      begin match Lwt_unix.getsockname fd with
+      | Lwt_unix.ADDR_INET(iaddr, port) ->
+        Ipaddr.V4 (Ipaddr.V4.of_string_exn (Unix.string_of_inet_addr iaddr)), port
+      | _ -> invalid_arg (fn_name ^ ": passed a non-TCP socket")
+      end
 end
 
 module Tcp = struct
@@ -159,30 +171,20 @@ module Tcp = struct
     read_buffer_size: int;
   }
 
-  let bind (ip, port) =
-    let addr = Lwt_unix.ADDR_INET(Unix.inet_addr_of_string @@ Ipaddr.to_string ip, port) in
+  let bind address =
     let fd = Lwt_unix.socket Lwt_unix.PF_INET Lwt_unix.SOCK_STREAM 0 in
     Lwt.catch
       (fun () ->
         Lwt_unix.setsockopt fd Lwt_unix.SO_REUSEADDR true;
-        Lwt_unix.bind fd addr;
-        Lwt.return fd
+        Lwt_unix.bind fd (sockaddr_of_address address);
+        Lwt.return (`Ok { server_fd = Some fd; read_buffer_size = default_read_buffer_size })
       ) (fun e ->
         Lwt_unix.close fd
         >>= fun () ->
-        Lwt.fail e
+        errorf "Tcp.bind failed to bind to %s: %s" (string_of_address address) (Printexc.to_string e)
       )
-    >>= fun fd ->
-    Lwt.return { server_fd = Some fd; read_buffer_size = default_read_buffer_size }
 
-  let getsockname server = match server.server_fd with
-    | None -> failwith "Tcp_server.getsockname: socket is closed"
-    | Some fd ->
-      begin match Lwt_unix.getsockname fd with
-      | Lwt_unix.ADDR_INET(iaddr, port) ->
-        Ipaddr.V4 (Ipaddr.V4.of_string_exn (Unix.string_of_inet_addr iaddr)), port
-      | _ -> invalid_arg "Tcp_server.getsockname passed a non-TCP socket"
-      end
+  let getsockname server = getsockname "Tcp.getsockname" server.server_fd
 
   let shutdown server = match server.server_fd with
     | None -> Lwt.return_unit
@@ -246,18 +248,26 @@ module Udp = struct
   type flow = {
     mutable fd: Lwt_unix.file_descr option;
     read_buffer_size: int;
-    address: address;
+    mutable already_read: Cstruct.t option;
+    sockaddr: Unix.sockaddr;
   }
 
   let connect ?(read_buffer_size = max_udp_length) address =
     let fd = Lwt_unix.socket Lwt_unix.PF_INET Lwt_unix.SOCK_DGRAM 0 in
     (* Win32 requires all sockets to be bound however macOS and Linux don't *)
     (try Lwt_unix.bind fd (Lwt_unix.ADDR_INET(Unix.inet_addr_any, 0)) with _ -> ());
-    Lwt.return (`Ok { fd = Some fd; read_buffer_size; address })
+    let already_read = None in
+    let sockaddr = sockaddr_of_address address in
+    Lwt.return (`Ok { fd = Some fd; read_buffer_size; already_read; sockaddr })
 
-  let read t = match t.fd with
-    | None -> Lwt.return `Eof
-    | Some fd ->
+  let read t = match t.fd, t.already_read with
+    | None, _ -> Lwt.return `Eof
+    | Some _, Some data when Cstruct.len data > 0 ->
+      t.already_read <- Some (Cstruct.sub data 0 0); (* next read is `Eof *)
+      Lwt.return (`Ok data)
+    | Some _, Some _ ->
+      Lwt.return `Eof
+    | Some fd, None ->
       let buffer = Cstruct.create t.read_buffer_size in
       let bytes = Bytes.make t.read_buffer_size '\000' in
       Lwt.catch
@@ -281,8 +291,7 @@ module Udp = struct
           (* Lwt on Win32 doesn't support Lwt_bytes.sendto *)
           let bytes = Bytes.make (Cstruct.len buf) '\000' in
           Cstruct.blit_to_bytes buf 0 bytes 0 (Cstruct.len buf);
-          let remote_sockaddr = sockaddr_of_address t.address in
-          Lwt_unix.sendto fd bytes 0 (Bytes.length bytes) [] remote_sockaddr
+          Lwt_unix.sendto fd bytes 0 (Bytes.length bytes) [] t.sockaddr
           >>= fun _n ->
           Lwt.return (`Ok ())
         ) (fun e ->
@@ -300,5 +309,62 @@ module Udp = struct
 
   let shutdown_read _t = Lwt.return_unit
   let shutdown_write _t = Lwt.return_unit
+
+  type server = {
+    mutable server_fd: Lwt_unix.file_descr option;
+  }
+
+  let getsockname server = getsockname "Udp.getsockname" server.server_fd
+
+  let bind address =
+    let fd = Lwt_unix.socket Lwt_unix.PF_INET Lwt_unix.SOCK_DGRAM 0 in
+    try
+      let sockaddr = sockaddr_of_address address in
+      Lwt_unix.bind fd sockaddr;
+      Lwt.return (`Ok { server_fd = Some fd })
+    with
+    | e -> errorf "Udp.bind failed to bind address %s: %s"
+      (string_of_address address) (Printexc.to_string e)
+
+  let shutdown t = match t.server_fd with
+    | None -> Lwt.return_unit
+    | Some fd ->
+      t.server_fd <- None;
+      Lwt_unix.close fd
+
+  let listen t flow_cb =
+    let buffer = Cstruct.create max_udp_length in
+    let bytes = Bytes.make max_udp_length '\000' in
+    match t.server_fd with
+    | None -> ()
+    | Some fd ->
+      let rec loop () =
+        Lwt.catch
+          (fun () ->
+            (* Lwt on Win32 doesn't support Lwt_bytes.recvfrom *)
+            Lwt_unix.recvfrom fd bytes 0 (Bytes.length bytes) []
+            >>= fun (n, sockaddr) ->
+            Cstruct.blit_from_bytes bytes 0 buffer 0 n;
+            let data = Cstruct.sub buffer 0 n in
+            (* construct a flow with this buffer available for reading *)
+            let flow = { fd = Some fd; read_buffer_size = 0; already_read = Some data; sockaddr } in
+            Lwt.async
+              (fun () ->
+                Lwt.catch
+                  (fun () -> flow_cb flow)
+                  (fun e ->
+                    Log.info (fun f -> f "Udp.listen callback caught: %s" (Printexc.to_string e));
+                    Lwt.return_unit
+                  )
+              );
+            Lwt.return true
+          ) (fun e ->
+            Log.err (fun f -> f "Udp.listen: caught %s shutting down server" (Printexc.to_string e));
+            Lwt.return false
+          )
+        >>= function
+        | false -> Lwt.return_unit
+        | true -> loop () in
+      Lwt.async loop
 
 end

--- a/lib/dns_forward_lwt_unix.mli
+++ b/lib/dns_forward_lwt_unix.mli
@@ -15,28 +15,5 @@
  *
  *)
 
-module Tcp: sig
-  type address = Ipaddr.t * int
-
-  type flow
-
-  include Dns_forward_s.CLIENT
-    with type address := address
-     and type flow := flow
-  include Dns_forward_s.SERVER
-    with type address := address
-     and type flow := flow
-end
-
-module Udp: sig
-  type address = Ipaddr.t * int
-
-  type flow
-
-  include Dns_forward_s.CLIENT
-    with type address := address
-     and type flow := flow
-  include Dns_forward_s.SERVER
-    with type address := address
-    and type flow := flow
-end
+module Tcp: Dns_forward_s.TCPIP
+module Udp: Dns_forward_s.TCPIP

--- a/lib/dns_forward_lwt_unix.mli
+++ b/lib/dns_forward_lwt_unix.mli
@@ -15,5 +15,15 @@
  *
  *)
 
- module Tcp_client: Dns_forward_s.CLIENT
- (* module Tcp_server: Dns_forward_s.SERVER*)
+module Tcp: sig
+  type address = Ipaddr.t * int
+
+  type flow
+
+  include Dns_forward_s.CLIENT
+    with type address := address
+     and type flow := flow
+  include Dns_forward_s.SERVER
+    with type address := address
+     and type flow := flow
+end

--- a/lib/dns_forward_lwt_unix.mli
+++ b/lib/dns_forward_lwt_unix.mli
@@ -27,3 +27,13 @@ module Tcp: sig
     with type address := address
      and type flow := flow
 end
+
+module Udp: sig
+  type address = Ipaddr.t * int
+
+  type flow
+
+  include Dns_forward_s.CLIENT
+    with type address := address
+     and type flow := flow
+end

--- a/lib/dns_forward_lwt_unix.mli
+++ b/lib/dns_forward_lwt_unix.mli
@@ -36,4 +36,7 @@ module Udp: sig
   include Dns_forward_s.CLIENT
     with type address := address
      and type flow := flow
+  include Dns_forward_s.SERVER
+    with type address := address
+    and type flow := flow
 end

--- a/lib/dns_forward_s.mli
+++ b/lib/dns_forward_s.mli
@@ -32,7 +32,7 @@ module type SERVER = sig
 
   type address
 
-  val bind: address -> server Lwt.t
+  val bind: address -> [ `Ok of server | `Error of [ `Msg of string ]] Lwt.t
   (** Bind a server to an address *)
 
   val getsockname: server -> address

--- a/lib/dns_forward_s.mli
+++ b/lib/dns_forward_s.mli
@@ -47,3 +47,17 @@ module type SERVER = sig
   val shutdown: server -> unit Lwt.t
   (** Stop accepting connections on the given server *)
 end
+
+module type TCPIP = sig
+  type address = Ipaddr.t * int
+
+  type flow
+
+  include CLIENT
+    with type address := address
+     and type flow := flow
+  include SERVER
+    with type address := address
+     and type flow := flow
+
+end

--- a/opam
+++ b/opam
@@ -20,6 +20,7 @@ depends: [
   "ppx_tools"  {build}
   "cmdliner"
   "mirage-flow"
+  "dns"
   "rresult" "astring" "fmt"
   "cstruct"     {>= "2.2"}
   "result" "lwt"


### PR DESCRIPTION
Note in the server case we represent received UDP datagrams as short "flows" containing just the one packet, but which allow replies via `write`.