### PR TITLE
Functorise over RPC_SERVER and RPC_CLIENT

### DIFF
--- a/_tags
+++ b/_tags
@@ -1,7 +1,7 @@
 true : bin_annot, safe_string
 true: warn_error(+1..49), warn(A-3-4-41-44)
 true: package(bytes lwt astring logs result cstruct fmt rresult ipaddr)
-true: package(dns mirage-flow cstruct.lwt)
+true: package(dns mirage-flow cstruct.lwt channel io-page.unix)
 
 <bin>: include
 <lib>: include

--- a/bin/impl.ml
+++ b/bin/impl.ml
@@ -40,11 +40,11 @@ module Time = struct
   let sleep = Lwt_unix.sleep
 end
 
-module Udp_client = Dns_forward_udp.Make(Dns_forward_lwt_unix.Udp)
-module Udp_forwarder = Dns_forward.Make(Dns_forward_lwt_unix.Udp)(Udp_client)(Time)
+module Udp = Dns_forward_udp.Make(Dns_forward_lwt_unix.Udp)
+module Udp_forwarder = Dns_forward.Make(Udp)(Udp)(Time)
 
-module Tcp_client = Dns_forward_tcp.Make(Dns_forward_lwt_unix.Tcp)
-module Tcp_forwarder = Dns_forward.Make(Dns_forward_lwt_unix.Tcp)(Tcp_client)(Time)
+module Tcp = Dns_forward_tcp.Make(Dns_forward_lwt_unix.Tcp)
+module Tcp_forwarder = Dns_forward.Make(Tcp)(Tcp)(Time)
 
 let max_udp_length = 65507
 
@@ -58,7 +58,7 @@ let serve port filename =
     let config = Dns_forward_config.t_of_sexp @@ Sexplib.Sexp.of_string all in
     let udp = Udp_forwarder.make config in
     let tcp = Tcp_forwarder.make config in
-    let address = Ipaddr.V4 Ipaddr.V4.localhost, port in
+    let address = { Dns_forward_config.ip = Ipaddr.V4 Ipaddr.V4.localhost; port } in
     let t =
       let open Dns_forward_error.Infix in
       Udp_forwarder.serve udp address

--- a/bin/impl.ml
+++ b/bin/impl.ml
@@ -39,7 +39,9 @@ module Time = struct
   type 'a io = 'a Lwt.t
   let sleep = Lwt_unix.sleep
 end
-module Forwarder = Dns_forward.Make(Dns_forward_lwt_unix.Udp)(Dns_forward_lwt_unix.Udp)(Time)
+
+module Udp_client = Dns_forward_udp.Make(Dns_forward_lwt_unix.Udp)
+module Forwarder = Dns_forward.Make(Dns_forward_lwt_unix.Udp)(Udp_client)(Time)
 
 let max_udp_length = 65507
 

--- a/bin/impl.ml
+++ b/bin/impl.ml
@@ -41,7 +41,10 @@ module Time = struct
 end
 
 module Udp_client = Dns_forward_udp.Make(Dns_forward_lwt_unix.Udp)
-module Forwarder = Dns_forward.Make(Dns_forward_lwt_unix.Udp)(Udp_client)(Time)
+module Udp_forwarder = Dns_forward.Make(Dns_forward_lwt_unix.Udp)(Udp_client)(Time)
+
+module Tcp_client = Dns_forward_tcp.Make(Dns_forward_lwt_unix.Tcp)
+module Tcp_forwarder = Dns_forward.Make(Dns_forward_lwt_unix.Tcp)(Tcp_client)(Time)
 
 let max_udp_length = 65507
 
@@ -53,11 +56,18 @@ let serve port filename =
     >>= fun lines ->
     let all = String.concat "" lines in
     let config = Dns_forward_config.t_of_sexp @@ Sexplib.Sexp.of_string all in
-    let forwarder = Forwarder.make config in
-    Forwarder.serve forwarder (Ipaddr.V4 Ipaddr.V4.localhost, port)
-    >>= function
-    | `Error (`Msg _) -> Lwt.return (`Error(true, "please supply a free port number"))
-    | `Ok () ->
+    let udp = Udp_forwarder.make config in
+    let tcp = Tcp_forwarder.make config in
+    let address = Ipaddr.V4 Ipaddr.V4.localhost, port in
+    let t =
+      let open Dns_forward_error.Infix in
+      Udp_forwarder.serve udp address
+      >>= fun () ->
+      Tcp_forwarder.serve tcp address
+      >>= fun () ->
       let t, _ = Lwt.task () in
-      t
+      t in
+    t >>= function
+    | `Error (`Msg m) -> Lwt.return (`Error(true, m))
+    | `Ok () -> Lwt.return (`Ok ())
   end

--- a/lib/dns-forward.mllib
+++ b/lib/dns-forward.mllib
@@ -2,4 +2,5 @@ Dns_forward
 Dns_forward_config
 Dns_forward_lwt_unix
 Dns_forward_udp
+Dns_forward_tcp
 Dns_forward_error

--- a/lib/dns-forward.mllib
+++ b/lib/dns-forward.mllib
@@ -1,3 +1,5 @@
 Dns_forward
 Dns_forward_config
 Dns_forward_lwt_unix
+Dns_forward_udp
+Dns_forward_error

--- a/lib/dns_forward.mli
+++ b/lib/dns_forward.mli
@@ -15,7 +15,7 @@
  *
  *)
 
- module Make(Input: Dns_forward_s.TCPIP)(Client: Dns_forward_s.RPC_CLIENT)(Time: V1_LWT.TIME): sig
+ module Make(Server: Dns_forward_s.RPC_SERVER)(Client: Dns_forward_s.RPC_CLIENT)(Time: V1_LWT.TIME): sig
 
   type t
   (** A forwarding DNS proxy *)
@@ -23,9 +23,9 @@
   val make: Dns_forward_config.t -> t
   (** Construct a forwarding DNS proxy given some configuration *)
 
-  val answer: t -> Cstruct.t -> Cstruct.t option Lwt.t
+  val answer: t -> Cstruct.t -> [ `Ok of Cstruct.t | `Error of [ `Msg of string ] ] Lwt.t
   (** Given a DNS request, construct an response *)
 
-  val serve: t -> (Ipaddr.t * int) -> [ `Ok of unit | `Error of [ `Msg of string ] ] Lwt.t
+  val serve: t -> Dns_forward_config.address -> [ `Ok of unit | `Error of [ `Msg of string ] ] Lwt.t
   (** Serve requests on the given IP and port forever *)
  end

--- a/lib/dns_forward.mli
+++ b/lib/dns_forward.mli
@@ -15,7 +15,7 @@
  *
  *)
 
- module Make(Tcpip: Dns_forward_s.TCPIP)(Time: V1_LWT.TIME): sig
+ module Make(Input: Dns_forward_s.TCPIP)(Output: Dns_forward_s.TCPIP)(Time: V1_LWT.TIME): sig
 
   type t
   (** A forwarding DNS proxy *)
@@ -26,4 +26,6 @@
   val answer: t -> Cstruct.t -> Cstruct.t option Lwt.t
   (** Given a DNS request, construct an response *)
 
+  val serve: t -> (Ipaddr.t * int) -> [ `Ok of unit | `Error of [ `Msg of string ] ] Lwt.t
+  (** Serve requests on the given IP and port forever *)
  end

--- a/lib/dns_forward_error.ml
+++ b/lib/dns_forward_error.ml
@@ -14,18 +14,17 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
  *)
+open Lwt.Infix
 
- module Make(Input: Dns_forward_s.TCPIP)(Client: Dns_forward_s.RPC_CLIENT)(Time: V1_LWT.TIME): sig
+module Infix = struct
+  let (>>=) m f = m >>= function
+    | `Error (`Msg m) -> Lwt.return (`Error (`Msg m))
+    | `Ok x -> f x
+end
 
-  type t
-  (** A forwarding DNS proxy *)
-
-  val make: Dns_forward_config.t -> t
-  (** Construct a forwarding DNS proxy given some configuration *)
-
-  val answer: t -> Cstruct.t -> Cstruct.t option Lwt.t
-  (** Given a DNS request, construct an response *)
-
-  val serve: t -> (Ipaddr.t * int) -> [ `Ok of unit | `Error of [ `Msg of string ] ] Lwt.t
-  (** Serve requests on the given IP and port forever *)
- end
+module FromFlowError(Flow: V1_LWT.FLOW) = struct
+  let (>>=) m f = m >>= function
+    | `Eof -> Lwt.return (`Error (`Msg "Unexpected end of file"))
+    | `Error e -> Lwt.return (`Error (`Msg (Flow.error_message e)))
+    | `Ok x -> f x
+end

--- a/lib/dns_forward_error.mli
+++ b/lib/dns_forward_error.mli
@@ -15,17 +15,13 @@
  *
  *)
 
- module Make(Input: Dns_forward_s.TCPIP)(Client: Dns_forward_s.RPC_CLIENT)(Time: V1_LWT.TIME): sig
+module Infix: sig
+  val (>>=): [< `Error of [< `Msg of 'a ] | `Ok of 'b ] Lwt.t ->
+    ('b -> ([> `Error of [> `Msg of 'a ] ] as 'c) Lwt.t) -> 'c Lwt.t
+end
 
-  type t
-  (** A forwarding DNS proxy *)
+module FromFlowError(Flow: V1_LWT.FLOW): sig
+  val (>>=): [< `Eof | `Error of Flow.error | `Ok of 'b ] Lwt.t ->
+    ('b -> ([> `Error of [> `Msg of string ] ] as 'c) Lwt.t) -> 'c Lwt.t
 
-  val make: Dns_forward_config.t -> t
-  (** Construct a forwarding DNS proxy given some configuration *)
-
-  val answer: t -> Cstruct.t -> Cstruct.t option Lwt.t
-  (** Given a DNS request, construct an response *)
-
-  val serve: t -> (Ipaddr.t * int) -> [ `Ok of unit | `Error of [ `Msg of string ] ] Lwt.t
-  (** Serve requests on the given IP and port forever *)
- end
+end

--- a/lib/dns_forward_s.mli
+++ b/lib/dns_forward_s.mli
@@ -15,7 +15,7 @@
  *
  *)
 
-module type CLIENT = sig
+module type FLOW_CLIENT = sig
   include Mirage_flow_s.SHUTDOWNABLE
 
   type address
@@ -26,7 +26,7 @@ module type CLIENT = sig
       he connected flow. *)
 end
 
-module type SERVER = sig
+module type FLOW_SERVER = sig
   type server
   (* A server bound to some address *)
 
@@ -53,11 +53,10 @@ module type TCPIP = sig
 
   type flow
 
-  include CLIENT
+  include FLOW_CLIENT
     with type address := address
      and type flow := flow
-  include SERVER
+  include FLOW_SERVER
     with type address := address
      and type flow := flow
-
 end

--- a/lib/dns_forward_s.mli
+++ b/lib/dns_forward_s.mli
@@ -60,3 +60,20 @@ module type TCPIP = sig
     with type address := address
      and type flow := flow
 end
+
+module type RPC_CLIENT = sig
+  type request = Cstruct.t
+  type response = Cstruct.t
+  type address = Dns_forward_config.address
+  type t
+  val connect: address -> [ `Ok of t | `Error of [ `Msg of string ] ] Lwt.t
+  val rpc: t -> request -> [ `Ok of response | `Error of [ `Msg of string ] ] Lwt.t
+  val disconnect: t -> unit Lwt.t
+end
+
+module type RPC_SERVER = sig
+  type request
+  type response
+  type t
+  val listen: t -> (request -> response option Lwt.t) -> unit Lwt.t
+end

--- a/lib/dns_forward_s.mli
+++ b/lib/dns_forward_s.mli
@@ -72,8 +72,12 @@ module type RPC_CLIENT = sig
 end
 
 module type RPC_SERVER = sig
-  type request
-  type response
-  type t
-  val listen: t -> (request -> response option Lwt.t) -> unit Lwt.t
+  type request = Cstruct.t
+  type response = Cstruct.t
+  type address = Dns_forward_config.address
+
+  type server
+  val bind: address -> [ `Ok of server | `Error of [ `Msg of string ] ] Lwt.t
+  val listen: server -> (request -> [ `Ok of response | `Error of [ `Msg of string ] ] Lwt.t) -> [`Ok of unit | `Error of [ `Msg of string ]] Lwt.t
+  val shutdown: server -> unit Lwt.t
 end

--- a/lib/dns_forward_tcp.ml
+++ b/lib/dns_forward_tcp.ml
@@ -1,0 +1,71 @@
+(*
+ * Copyright (C) 2016 David Scott <dave@recoil.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ *)
+
+let src =
+  let src = Logs.Src.create "Dns_forward" ~doc:"DNS over TCP" in
+  Logs.Src.set_level src (Some Logs.Debug);
+  src
+
+module Log = (val Logs.src_log src : Logs.LOG)
+
+module Make(Tcp: Dns_forward_s.TCPIP) = struct
+  type address = Dns_forward_config.address
+
+  module C = Channel.Make(Tcp)
+
+  type t = {
+    address: address;
+    c: C.t;
+  }
+
+  type request = Cstruct.t
+  type response = Cstruct.t
+
+  module Error = Dns_forward_error.Infix
+  module FlowError = Dns_forward_error.FromFlowError(Tcp)
+
+  let connect address =
+    Log.debug (fun f -> f "forwarding to server %s:%d"
+      (Ipaddr.to_string address.Dns_forward_config.ip)
+      address.Dns_forward_config.port);
+    let open Error in
+    Tcp.connect (address.Dns_forward_config.ip, address.Dns_forward_config.port)
+    >>= fun flow ->
+    let c = C.create flow in
+    Lwt.return (`Ok { address; c })
+
+  let disconnect { c; _ } =
+    Tcp.close @@ C.to_flow c
+
+  let rpc (t: t) request =
+    let open Lwt.Infix in
+    (* RFC 1035 4.2.2 TCP Usage: 2 byte length field *)
+    let header = Cstruct.create 2 in
+    Cstruct.BE.set_uint16 header 0 (Cstruct.len request);
+    C.write_buffer t.c header;
+    C.write_buffer t.c request;
+    C.flush t.c
+    >>= fun () ->
+    C.read_exactly ~len:2 t.c
+    >>= fun bufs ->
+    let buf = Cstruct.concat bufs in
+    let len = Cstruct.BE.get_uint16 buf 0 in
+    C.read_exactly ~len t.c
+    >>= fun bufs ->
+    Lwt.return (`Ok (Cstruct.concat bufs))
+
+end

--- a/lib/dns_forward_tcp.ml
+++ b/lib/dns_forward_tcp.ml
@@ -51,21 +51,65 @@ module Make(Tcp: Dns_forward_s.TCPIP) = struct
   let disconnect { c; _ } =
     Tcp.close @@ C.to_flow c
 
-  let rpc (t: t) request =
-    let open Lwt.Infix in
+  let write_buffer c buffer =
     (* RFC 1035 4.2.2 TCP Usage: 2 byte length field *)
     let header = Cstruct.create 2 in
-    Cstruct.BE.set_uint16 header 0 (Cstruct.len request);
-    C.write_buffer t.c header;
-    C.write_buffer t.c request;
-    C.flush t.c
-    >>= fun () ->
-    C.read_exactly ~len:2 t.c
+    Cstruct.BE.set_uint16 header 0 (Cstruct.len buffer);
+    C.write_buffer c header;
+    C.write_buffer c buffer;
+    C.flush c
+
+  let read_buffer c =
+    let open Lwt.Infix in
+    C.read_exactly ~len:2 c
     >>= fun bufs ->
     let buf = Cstruct.concat bufs in
     let len = Cstruct.BE.get_uint16 buf 0 in
-    C.read_exactly ~len t.c
+    C.read_exactly ~len c
     >>= fun bufs ->
-    Lwt.return (`Ok (Cstruct.concat bufs))
+    Lwt.return (Cstruct.concat bufs)
+
+  let rpc (t: t) request =
+    let open Lwt.Infix in
+    write_buffer t.c request
+    >>= fun () ->
+    read_buffer t.c
+    >>= fun buf ->
+    Lwt.return (`Ok buf)
+
+  type server = {
+    address: address;
+    server: Tcp.server;
+  }
+
+  let bind address =
+    let open Error in
+    Tcp.bind (address.Dns_forward_config.ip, address.Dns_forward_config.port)
+    >>= fun server ->
+    Lwt.return (`Ok { address; server })
+
+  let listen { server; _ } cb =
+    let open Lwt.Infix in
+    Tcp.listen server (fun flow ->
+      let c = C.create flow in
+      let rec loop () =
+        read_buffer c
+        >>= fun request ->
+        (* FIXME: need to run these in the background *)
+        (* FIXME: need to rewrite transaction IDs if the requests come from
+           different resolvers *)
+        cb request
+        >>= function
+        | `Error _ -> Lwt.return_unit
+        | `Ok response ->
+          write_buffer c response
+          >>= fun () ->
+          loop () in
+      loop ()
+    );
+    Lwt.return (`Ok ())
+
+  let shutdown server =
+    Tcp.shutdown server.server
 
 end

--- a/lib/dns_forward_tcp.mli
+++ b/lib/dns_forward_tcp.mli
@@ -1,0 +1,23 @@
+(*
+ * Copyright (C) 2016 David Scott <dave@recoil.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ *)
+
+(** DNS over TCP uses a simple header to delineate message boundaries *)
+
+module Make(Tcp: Dns_forward_s.TCPIP):
+  Dns_forward_s.RPC_CLIENT
+    with type request = Cstruct.t
+     and type response = Cstruct.t

--- a/lib/dns_forward_tcp.mli
+++ b/lib/dns_forward_tcp.mli
@@ -17,7 +17,18 @@
 
 (** DNS over TCP uses a simple header to delineate message boundaries *)
 
-module Make(Tcp: Dns_forward_s.TCPIP):
-  Dns_forward_s.RPC_CLIENT
-    with type request = Cstruct.t
-     and type response = Cstruct.t
+module Make(Tcp: Dns_forward_s.TCPIP): sig
+  type request = Cstruct.t
+  type response = Cstruct.t
+  type address = Dns_forward_config.address
+
+  include Dns_forward_s.RPC_CLIENT
+    with type request  := request
+     and type response := response
+     and type address  := address
+
+  include Dns_forward_s.RPC_SERVER
+    with type request  := request
+     and type response := response
+     and type address  := address
+end

--- a/lib/dns_forward_udp.ml
+++ b/lib/dns_forward_udp.ml
@@ -1,0 +1,59 @@
+(*
+ * Copyright (C) 2016 David Scott <dave@recoil.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ *)
+
+let src =
+  let src = Logs.Src.create "Dns_forward" ~doc:"DNS over UDP" in
+  Logs.Src.set_level src (Some Logs.Debug);
+  src
+
+module Log = (val Logs.src_log src : Logs.LOG)
+
+module Make(Udp: Dns_forward_s.TCPIP) = struct
+  type address = Dns_forward_config.address
+
+  type t = {
+    address: address;
+    flow: Udp.flow;
+  }
+
+  type request = Cstruct.t
+  type response = Cstruct.t
+
+  module Error = Dns_forward_error.Infix
+  module FlowError = Dns_forward_error.FromFlowError(Udp)
+
+  let connect address =
+    Log.debug (fun f -> f "forwarding to server %s:%d"
+      (Ipaddr.to_string address.Dns_forward_config.ip)
+      address.Dns_forward_config.port);
+    let open Error in
+    Udp.connect (address.Dns_forward_config.ip, address.Dns_forward_config.port)
+    >>= fun flow ->
+    Lwt.return (`Ok { address; flow })
+
+  let disconnect { flow; _ } =
+    Udp.close flow
+
+  let rpc (t: t) request =
+    let open FlowError in
+    Udp.write t.flow request
+    >>= fun () ->
+    Udp.read t.flow
+    >>= fun reply ->
+    Lwt.return (`Ok reply)
+
+end

--- a/lib/dns_forward_udp.mli
+++ b/lib/dns_forward_udp.mli
@@ -15,17 +15,9 @@
  *
  *)
 
- module Make(Input: Dns_forward_s.TCPIP)(Client: Dns_forward_s.RPC_CLIENT)(Time: V1_LWT.TIME): sig
+(** DNS over UDP uses the UDP datagrams to delineate message boundaries *)
 
-  type t
-  (** A forwarding DNS proxy *)
-
-  val make: Dns_forward_config.t -> t
-  (** Construct a forwarding DNS proxy given some configuration *)
-
-  val answer: t -> Cstruct.t -> Cstruct.t option Lwt.t
-  (** Given a DNS request, construct an response *)
-
-  val serve: t -> (Ipaddr.t * int) -> [ `Ok of unit | `Error of [ `Msg of string ] ] Lwt.t
-  (** Serve requests on the given IP and port forever *)
- end
+module Make(Udp: Dns_forward_s.TCPIP):
+  Dns_forward_s.RPC_CLIENT
+    with type request = Cstruct.t
+     and type response = Cstruct.t

--- a/lib/dns_forward_udp.mli
+++ b/lib/dns_forward_udp.mli
@@ -17,7 +17,18 @@
 
 (** DNS over UDP uses the UDP datagrams to delineate message boundaries *)
 
-module Make(Udp: Dns_forward_s.TCPIP):
-  Dns_forward_s.RPC_CLIENT
-    with type request = Cstruct.t
-     and type response = Cstruct.t
+module Make(Udp: Dns_forward_s.TCPIP): sig
+  type request = Cstruct.t
+  type response = Cstruct.t
+  type address = Dns_forward_config.address
+
+  include Dns_forward_s.RPC_CLIENT
+    with type request  := request
+     and type response := response
+     and type address  := address
+
+  include Dns_forward_s.RPC_SERVER
+    with type request  := request
+     and type response := response
+     and type address  := address
+end

--- a/opam
+++ b/opam
@@ -20,6 +20,7 @@ depends: [
   "ppx_tools"  {build}
   "cmdliner"
   "mirage-flow"
+  "channel"
   "dns"
   "rresult" "astring" "fmt"
   "cstruct"     {>= "2.2"}


### PR DESCRIPTION
Previously we functorised over byte-stream level `FLOW_CLIENT` and `FLOW_SERVER`, but this doesn't work for Tcp where there is an extra level of framing.