### PR TITLE
Persist, timeout and reconnect TCP connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,7 @@ and then send queries as follows:
 dig @127.0.0.1 -p 5555 www.google.com
 dig @127.0.0.1 -p 5555 www.docker.com
 ```
+
+## References
+
+- [DNS Transport over TCP - Implementation Requirements](https://tools.ietf.org/html/rfc5966)

--- a/bin/impl.ml
+++ b/bin/impl.ml
@@ -43,7 +43,7 @@ end
 module Udp = Dns_forward_udp.Make(Dns_forward_lwt_unix.Udp)
 module Udp_forwarder = Dns_forward.Make(Udp)(Udp)(Time)
 
-module Tcp = Dns_forward_tcp.Make(Dns_forward_lwt_unix.Tcp)
+module Tcp = Dns_forward_tcp.Make(Dns_forward_lwt_unix.Tcp)(Time)
 module Tcp_forwarder = Dns_forward.Make(Tcp)(Tcp)(Time)
 
 let max_udp_length = 65507

--- a/lib/dns_forward_error.ml
+++ b/lib/dns_forward_error.ml
@@ -28,3 +28,5 @@ module FromFlowError(Flow: V1_LWT.FLOW) = struct
     | `Error e -> Lwt.return (`Error (`Msg (Flow.error_message e)))
     | `Ok x -> f x
 end
+
+let errorf fmt = Printf.ksprintf (fun s -> Lwt.return (`Error (`Msg s))) fmt

--- a/lib/dns_forward_error.mli
+++ b/lib/dns_forward_error.mli
@@ -25,3 +25,5 @@ module FromFlowError(Flow: V1_LWT.FLOW): sig
     ('b -> ([> `Error of [> `Msg of string ] ] as 'c) Lwt.t) -> 'c Lwt.t
 
 end
+
+val errorf: ('a, unit, string, [> `Error of [> `Msg of string ] ] Lwt.t) format4 -> 'a

--- a/lib/dns_forward_tcp.mli
+++ b/lib/dns_forward_tcp.mli
@@ -17,7 +17,7 @@
 
 (** DNS over TCP uses a simple header to delineate message boundaries *)
 
-module Make(Tcp: Dns_forward_s.TCPIP): sig
+module Make(Tcp: Dns_forward_s.TCPIP)(Time: V1_LWT.TIME): sig
   type request = Cstruct.t
   type response = Cstruct.t
   type address = Dns_forward_config.address


### PR DESCRIPTION
- TCP connections are (re)-connected on use
- TCP connections are closed 30s after the last RPC starts