### PR TITLE
Multiplex over one outgoing TCP connection

### DIFF
--- a/bin/impl.ml
+++ b/bin/impl.ml
@@ -56,8 +56,10 @@ let serve port filename =
     >>= fun lines ->
     let all = String.concat "" lines in
     let config = Dns_forward_config.t_of_sexp @@ Sexplib.Sexp.of_string all in
-    let udp = Udp_forwarder.make config in
-    let tcp = Tcp_forwarder.make config in
+    Udp_forwarder.make config
+    >>= fun udp ->
+    Tcp_forwarder.make config
+    >>= fun tcp ->
     let address = { Dns_forward_config.ip = Ipaddr.V4 Ipaddr.V4.localhost; port } in
     let t =
       let open Dns_forward_error.Infix in

--- a/bin/impl.ml
+++ b/bin/impl.ml
@@ -48,7 +48,15 @@ module Tcp_forwarder = Dns_forward.Make(Tcp)(Tcp)(Time)
 
 let max_udp_length = 65507
 
+let set_signal_if_supported signal handler =
+  try
+    Sys.set_signal signal handler
+  with Invalid_argument _ ->
+    ()
+
 let serve port filename =
+  set_signal_if_supported Sys.sigpipe Sys.Signal_ignore;
+
   if filename = "" then begin
     `Error (true, "please supply the name of a config file")
   end else Lwt_main.run begin

--- a/lib/dns_forward.mli
+++ b/lib/dns_forward.mli
@@ -20,7 +20,7 @@
   type t
   (** A forwarding DNS proxy *)
 
-  val make: Dns_forward_config.t -> t
+  val make: Dns_forward_config.t -> t Lwt.t
   (** Construct a forwarding DNS proxy given some configuration *)
 
   val answer: t -> Cstruct.t -> [ `Ok of Cstruct.t | `Error of [ `Msg of string ] ] Lwt.t

--- a/lib/dns_forward_tcp.ml
+++ b/lib/dns_forward_tcp.ml
@@ -140,9 +140,6 @@ module Make(Tcp: Dns_forward_s.TCPIP)(Time: V1_LWT.TIME) = struct
   type response = Cstruct.t
 
   let connect address =
-    Log.debug (fun f -> f "forwarding to server %s:%d"
-      (Ipaddr.to_string address.Dns_forward_config.ip)
-      address.Dns_forward_config.port);
     let c = None in
     let m = Lwt_mutex.create () in
     let disconnect_on_idle = Lwt.return_unit in
@@ -187,7 +184,6 @@ module Make(Tcp: Dns_forward_s.TCPIP)(Time: V1_LWT.TIME) = struct
         get_c t
         >>= fun c ->
         let open Lwt.Infix in
-
         (* An existing connection to the server might have been closed by the server;
            therefore if we fail to write the request, reconnect and try once more. *)
         Lwt_mutex.with_lock t.write_m (fun () -> write_buffer c buffer)

--- a/lib/dns_forward_tcp.ml
+++ b/lib/dns_forward_tcp.ml
@@ -92,7 +92,7 @@ module Make(Tcp: Dns_forward_s.TCPIP)(Time: V1_LWT.TIME) = struct
       >>= function
       | `Error (`Msg m) ->
         Log.info (fun f -> f "%s: dispatcher shutting down" m);
-        Lwt.return_unit
+        disconnect t
       | `Ok buffer ->
         let buf = Dns.Buf.of_cstruct buffer in
         begin match Dns.Protocol.Server.parse (Dns.Buf.sub buf 0 (Cstruct.len buffer)) with

--- a/lib/dns_forward_tcp.ml
+++ b/lib/dns_forward_tcp.ml
@@ -31,7 +31,9 @@ module Make(Tcp: Dns_forward_s.TCPIP)(Time: V1_LWT.TIME) = struct
     address: address;
     mutable c: C.t option;
     mutable disconnect_on_idle: unit Lwt.t;
+    wakeners: (int, [ `Ok of Cstruct.t | `Error of [ `Msg of string ] ] Lwt.u) Hashtbl.t;
     m: Lwt_mutex.t;
+    write_m: Lwt_mutex.t;
   }
 
   module Error = Dns_forward_error.Infix
@@ -43,55 +45,16 @@ module Make(Tcp: Dns_forward_s.TCPIP)(Time: V1_LWT.TIME) = struct
       t.c <- None;
       Lwt_mutex.with_lock m
         (fun () ->
+          let tbl = Hashtbl.copy t.wakeners in
+          Hashtbl.clear t.wakeners;
+          let error = `Error (`Msg "connection to server was closed") in
+          Hashtbl.iter (fun id u ->
+            Log.err (fun f -> f "disconnect: failing request with id %d" id);
+            Lwt.wakeup_later u error
+          ) tbl;
           Tcp.close @@ C.to_flow c
         )
     | _ -> Lwt.return_unit
-
-  let get_c t =
-    let open Error in
-    Lwt.cancel t.disconnect_on_idle;
-    Lwt_mutex.with_lock t.m
-      (fun () -> match t.c with
-        | None ->
-          Tcp.connect (t.address.Dns_forward_config.ip, t.address.Dns_forward_config.port)
-          >>= fun flow ->
-          let c = C.create flow in
-          t.c <- Some c;
-          Lwt.return (`Ok c)
-        | Some c ->
-          Lwt.return (`Ok c))
-    >>= fun c ->
-    (* Add a fresh idle timer *)
-    t.disconnect_on_idle <- (let open Lwt.Infix in Time.sleep 30. >>= fun () -> disconnect t);
-    Lwt.return (`Ok c)
-
-  type request = Cstruct.t
-  type response = Cstruct.t
-
-  let connect address =
-    Log.debug (fun f -> f "forwarding to server %s:%d"
-      (Ipaddr.to_string address.Dns_forward_config.ip)
-      address.Dns_forward_config.port);
-    let c = None in
-    let m = Lwt_mutex.create () in
-    let disconnect_on_idle = Lwt.return_unit in
-    Lwt.return (`Ok { address; c; disconnect_on_idle; m })
-
-  let write_buffer c buffer =
-    (* RFC 1035 4.2.2 TCP Usage: 2 byte length field *)
-    let header = Cstruct.create 2 in
-    Cstruct.BE.set_uint16 header 0 (Cstruct.len buffer);
-    C.write_buffer c header;
-    C.write_buffer c buffer;
-    Lwt.catch
-      (fun () ->
-        let open Lwt.Infix in
-        C.flush c
-        >>= fun () ->
-        Lwt.return (`Ok ())
-      ) (fun e ->
-        errorf "Failed to write %d bytes: %s" (Cstruct.len buffer) (Printexc.to_string e)
-      )
 
   let read_buffer c =
     let open Error in
@@ -119,28 +82,127 @@ module Make(Tcp: Dns_forward_s.TCPIP)(Time: V1_LWT.TIME) = struct
     >>= fun bufs ->
     Lwt.return (`Ok (Cstruct.concat bufs))
 
-  let rpc (t: t) request =
-    let open Error in
-    (* If we fail to connect, return the error *)
-    get_c t
-    >>= fun c ->
+  (* Receive all the responses and demux to the right thread. When the connection
+     is closed, `read_buffer` will fail and this thread will exit. *)
+  let dispatcher t c () =
     let open Lwt.Infix in
-    (* An existing connection to the server might have been closed by the server;
-       therefore if we fail to write the request, reconnect and try once more. *)
-    write_buffer c request
-    >>= function
-    | `Ok () ->
+    let rec loop () =
       read_buffer c
-    | `Error (`Msg m) ->
-      Log.info (fun f -> f "caught %s writing request, attempting to reconnect" m);
-      disconnect t
+      >>= function
+      | `Error (`Msg m) ->
+        Log.info (fun f -> f "%s: dispatcher shutting down" m);
+        Lwt.return_unit
+      | `Ok buffer ->
+        let buf = Dns.Buf.of_cstruct buffer in
+        begin match Dns.Protocol.Server.parse (Dns.Buf.sub buf 0 (Cstruct.len buffer)) with
+        | None ->
+          Log.err (fun f -> f "failed to parse response");
+          Lwt.fail (Failure "failed to parse response")
+        | Some response ->
+          let client_id = response.Dns.Packet.id in
+          if Hashtbl.mem t.wakeners client_id then begin
+            let u = Hashtbl.find t.wakeners client_id in
+            Hashtbl.remove t.wakeners client_id;
+            Lwt.wakeup_later u (`Ok buffer)
+          end else begin
+            Log.err (fun f -> f "failed to find a wakener for id %d" client_id);
+          end;
+          loop ()
+        end
+    in
+    Lwt.catch loop
+      (fun e ->
+        Log.info (fun f -> f "dispatcher caught %s" (Printexc.to_string e));
+        Lwt.return_unit
+      )
+
+  let get_c t =
+    let open Error in
+    Lwt.cancel t.disconnect_on_idle;
+    Lwt_mutex.with_lock t.m
+      (fun () -> match t.c with
+        | None ->
+          Tcp.connect (t.address.Dns_forward_config.ip, t.address.Dns_forward_config.port)
+          >>= fun flow ->
+          let c = C.create flow in
+          t.c <- Some c;
+          Lwt.async (dispatcher t c);
+          Lwt.return (`Ok c)
+        | Some c ->
+          Lwt.return (`Ok c))
+    >>= fun c ->
+    (* Add a fresh idle timer *)
+    t.disconnect_on_idle <- (let open Lwt.Infix in Time.sleep 30. >>= fun () -> disconnect t);
+    Lwt.return (`Ok c)
+
+  type request = Cstruct.t
+  type response = Cstruct.t
+
+  let connect address =
+    Log.debug (fun f -> f "forwarding to server %s:%d"
+      (Ipaddr.to_string address.Dns_forward_config.ip)
+      address.Dns_forward_config.port);
+    let c = None in
+    let m = Lwt_mutex.create () in
+    let disconnect_on_idle = Lwt.return_unit in
+    let wakeners = Hashtbl.create 7 in
+    let write_m = Lwt_mutex.create () in
+    Lwt.return (`Ok { address; c; disconnect_on_idle; wakeners; m; write_m })
+
+  let write_buffer c buffer =
+    (* RFC 1035 4.2.2 TCP Usage: 2 byte length field *)
+    let header = Cstruct.create 2 in
+    Cstruct.BE.set_uint16 header 0 (Cstruct.len buffer);
+    C.write_buffer c header;
+    C.write_buffer c buffer;
+    Lwt.catch
+      (fun () ->
+        let open Lwt.Infix in
+        C.flush c
+        >>= fun () ->
+        Lwt.return (`Ok ())
+      ) (fun e ->
+        errorf "Failed to write %d bytes: %s" (Cstruct.len buffer) (Printexc.to_string e)
+      )
+
+  let rpc (t: t) buffer =
+    let open Error in
+    let buf = Dns.Buf.of_cstruct buffer in
+    match Dns.Protocol.Server.parse (Dns.Buf.sub buf 0 (Cstruct.len buffer)) with
+    | None ->
+      Log.err (fun f -> f "failed to parse request");
+      Lwt.return (`Error (`Msg "failed to parse request"))
+    | Some request ->
+      (* FIXME: need to regenerate the id *)
+      let client_id = request.Dns.Packet.id in
+      let fresh_id = client_id in
+
+      let th, u = Lwt.task () in
+      Hashtbl.replace t.wakeners fresh_id u;
+      Lwt_mutex.with_lock t.write_m
+        (fun () ->
+          (* If we fail to connect, return the error *)
+          get_c t
+          >>= fun c ->
+          let open Lwt.Infix in
+
+          (* An existing connection to the server might have been closed by the server;
+             therefore if we fail to write the request, reconnect and try once more. *)
+          write_buffer c buffer
+          >>= function
+          | `Ok () ->
+            Lwt.return (`Ok ())
+          | `Error (`Msg m) ->
+            Log.info (fun f -> f "caught %s writing request, attempting to reconnect" m);
+            disconnect t
+            >>= fun () ->
+            let open Error in
+            get_c t
+            >>= fun c ->
+            write_buffer c buffer
+        )
       >>= fun () ->
-      let open Error in
-      get_c t
-      >>= fun c ->
-      write_buffer c request
-      >>= fun () ->
-      read_buffer c
+      th (* will be woken up by the dispatcher *)
 
   type server = {
     address: address;

--- a/lib/dns_forward_udp.ml
+++ b/lib/dns_forward_udp.ml
@@ -37,9 +37,6 @@ module Make(Udp: Dns_forward_s.TCPIP) = struct
   module FlowError = Dns_forward_error.FromFlowError(Udp)
 
   let connect address =
-    Log.debug (fun f -> f "forwarding to server %s:%d"
-      (Ipaddr.to_string address.Dns_forward_config.ip)
-      address.Dns_forward_config.port);
     let open Error in
     Udp.connect (address.Dns_forward_config.ip, address.Dns_forward_config.port)
     >>= fun flow ->


### PR DESCRIPTION
- connections are cached for re-use (for a limited time)
- if the remote end closes (e.g. google's DNS will close after 1s) then we `disconnect` our end too and will reconnect on demand later
- we maintain a mapping of request id received from the client to request ids used on the multiplexed link