### PR TITLE
Add extra local names to the forwarder

### DIFF
--- a/bin/impl.ml
+++ b/bin/impl.ml
@@ -71,9 +71,9 @@ let serve port filename =
     let address = { Dns_forward_config.ip = Ipaddr.V4 Ipaddr.V4.localhost; port } in
     let t =
       let open Dns_forward_error.Infix in
-      Udp_forwarder.serve udp address
+      Udp_forwarder.serve ~address udp
       >>= fun () ->
-      Tcp_forwarder.serve tcp address
+      Tcp_forwarder.serve ~address tcp
       >>= fun () ->
       let t, _ = Lwt.task () in
       t in

--- a/lib/dns_forward.ml
+++ b/lib/dns_forward.ml
@@ -77,7 +77,7 @@ module Make(Server: Dns_forward_s.RPC_SERVER)(Client: Dns_forward_s.RPC_CLIENT)(
     >>= fun connections ->
     Lwt.return { connections }
 
-  let answer t buffer =
+  let answer buffer t =
     let len = Cstruct.len buffer in
     let buf = Dns.Buf.of_cstruct buffer in
     match Dns.Protocol.Server.parse (Dns.Buf.sub buf 0 len) with
@@ -101,11 +101,11 @@ module Make(Server: Dns_forward_s.RPC_SERVER)(Client: Dns_forward_s.RPC_CLIENT)(
     | None ->
       Lwt.return (`Error (`Msg "failed to parse request"))
 
-  let serve t address =
+  let serve ~address t =
     let open Dns_forward_error.Infix in
     Server.bind address
     >>= fun server ->
-    Server.listen server (answer t)
+    Server.listen server (fun buf -> answer buf t)
     >>= fun () ->
     Lwt.return (`Ok ())
 end

--- a/lib/dns_forward.mli
+++ b/lib/dns_forward.mli
@@ -23,9 +23,9 @@
   val make: Dns_forward_config.t -> t Lwt.t
   (** Construct a forwarding DNS proxy given some configuration *)
 
-  val answer: t -> Cstruct.t -> [ `Ok of Cstruct.t | `Error of [ `Msg of string ] ] Lwt.t
+  val answer: Cstruct.t -> t -> [ `Ok of Cstruct.t | `Error of [ `Msg of string ] ] Lwt.t
   (** Given a DNS request, construct an response *)
 
-  val serve: t -> Dns_forward_config.address -> [ `Ok of unit | `Error of [ `Msg of string ] ] Lwt.t
+  val serve: address:Dns_forward_config.address -> t -> [ `Ok of unit | `Error of [ `Msg of string ] ] Lwt.t
   (** Serve requests on the given IP and port forever *)
  end

--- a/lib/dns_forward.mli
+++ b/lib/dns_forward.mli
@@ -23,9 +23,15 @@
   val make: Dns_forward_config.t -> t Lwt.t
   (** Construct a forwarding DNS proxy given some configuration *)
 
-  val answer: Cstruct.t -> t -> [ `Ok of Cstruct.t | `Error of [ `Msg of string ] ] Lwt.t
+  val answer:
+    ?local_names_cb:(Dns.Packet.question -> Dns.Packet.rr list option Lwt.t) ->
+    Cstruct.t ->
+    t -> [ `Ok of Cstruct.t | `Error of [ `Msg of string ] ] Lwt.t
   (** Given a DNS request, construct an response *)
 
-  val serve: address:Dns_forward_config.address -> t -> [ `Ok of unit | `Error of [ `Msg of string ] ] Lwt.t
-  (** Serve requests on the given IP and port forever *)
+  val serve:
+    address:Dns_forward_config.address ->
+    ?local_names_cb:(Dns.Packet.question -> Dns.Packet.rr list option Lwt.t) ->
+    t -> [ `Ok of unit | `Error of [ `Msg of string ] ] Lwt.t
+  (** Serve requests on the given [address] forever *)
  end

--- a/lib_test/server.ml
+++ b/lib_test/server.ml
@@ -23,7 +23,7 @@ module Make(Server: Dns_forward_s.RPC_SERVER) = struct
   }
   let make names = { names }
 
-  let answer t buffer =
+  let answer buffer t =
     let len = Cstruct.len buffer in
     let buf = Dns.Buf.of_cstruct buffer in
     match Dns.Protocol.Server.parse (Dns.Buf.sub buf 0 len) with
@@ -52,11 +52,11 @@ module Make(Server: Dns_forward_s.RPC_SERVER) = struct
     | None ->
       Lwt.return (`Error (`Msg "failed to parse request"))
 
-  let serve t address =
+  let serve ~address t =
     let open Error in
     Server.bind address
     >>= fun server ->
-    Server.listen server (answer t)
+    Server.listen server (fun buf -> answer buf t)
     >>= fun () ->
     Lwt.return (`Ok ())
 

--- a/lib_test/server.mli
+++ b/lib_test/server.mli
@@ -22,6 +22,6 @@ module Make(Server: Dns_forward_s.RPC_SERVER): sig
   val make: (string * Ipaddr.t) list -> t
   (** Construct a server with a fixed set of name mappings *)
 
-  val serve: t -> Dns_forward_config.address -> [ `Ok of unit | `Error of [ `Msg of string ] ] Lwt.t
+  val serve: address:Dns_forward_config.address -> t -> [ `Ok of unit | `Error of [ `Msg of string ] ] Lwt.t
   (** Serve requests on the given IP and port forever *)
 end

--- a/lib_test/test.ml
+++ b/lib_test/test.ml
@@ -35,7 +35,7 @@ let test_server () =
     let open Error in
     (* The virtual address we run our server on: *)
     let address = { Dns_forward_config.ip = Ipaddr.V4 Ipaddr.V4.localhost; port = 53 } in
-    S.serve s address
+    S.serve ~address s
     >>= fun () ->
     Rpc.connect address
     >>= fun c ->
@@ -64,12 +64,12 @@ let test_forwarder_zone () =
     let foo_server = S.make [ "foo", Ipaddr.of_string_exn foo_private ] in
     let foo_address = { Dns_forward_config.ip = Ipaddr.V4 Ipaddr.V4.localhost; port = 1 } in
     let open Error in
-    S.serve foo_server foo_address
+    S.serve ~address:foo_address foo_server
     >>= fun () ->
     (* a public server mapping 'foo' to a public ip *)
     let bar_server = S.make [ "foo", Ipaddr.of_string_exn foo_public ] in
     let bar_address = { Dns_forward_config.ip = Ipaddr.V4 Ipaddr.V4.localhost; port = 2 } in
-    S.serve bar_server bar_address
+    S.serve ~address:bar_address bar_server
     >>= fun () ->
     (* a forwarder which uses both servers *)
     let module F = Dns_forward.Make(Rpc)(Rpc)(Time) in
@@ -82,7 +82,7 @@ let test_forwarder_zone () =
     >>= fun f ->
     let f_address = { Dns_forward_config.ip = Ipaddr.V4 Ipaddr.V4.localhost; port = 3 } in
     let open Error in
-    F.serve f f_address
+    F.serve ~address:f_address f
     >>= fun () ->
     Rpc.connect f_address
     >>= fun c ->

--- a/lib_test/test.ml
+++ b/lib_test/test.ml
@@ -97,12 +97,57 @@ let test_forwarder_zone () =
   | `Ok () -> ()
   | `Error (`Msg m) -> failwith m
 
+let test_local_lookups () =
+  match Lwt_main.run begin
+    let module S = Server.Make(Rpc) in
+    let foo_public = "8.8.8.8" in
+    let foo_private = "192.168.1.1" in
+    (* a public server mapping 'foo' to a public ip *)
+    let public_server = S.make [ "foo", Ipaddr.of_string_exn foo_public ] in
+    let public_address = { Dns_forward_config.ip = Ipaddr.V4 Ipaddr.V4.localhost; port = 4 } in
+    let open Error in
+    S.serve ~address:public_address public_server
+    >>= fun () ->
+    let module F = Dns_forward.Make(Rpc)(Rpc)(Time) in
+    let config = [
+      { Dns_forward_config.address = public_address; zones = [] };
+    ] in
+    let open Lwt.Infix in
+    F.make config
+    >>= fun f ->
+    let f_address = { Dns_forward_config.ip = Ipaddr.V4 Ipaddr.V4.localhost; port = 5 } in
+    let local_names_cb question =
+      let open Dns.Packet in
+      match question with
+      | { q_name; q_type = Q_A; _ } ->
+        let rdata = A (Ipaddr.V4.of_string_exn foo_private) in
+        let name = q_name and cls = RR_IN and flush = false and ttl = 100l in
+        Lwt.return (Some [ { name; cls; flush; ttl; rdata } ])
+      | _ ->
+        Lwt.return None in
+    let open Error in
+    F.serve ~address:f_address ~local_names_cb f
+    >>= fun () ->
+    Rpc.connect f_address
+    >>= fun c ->
+    let request = make_a_query (Dns.Name.of_string "foo") in
+    Rpc.rpc c request
+    >>= fun response ->
+    parse_response response
+    >>= fun ipv4 ->
+    Alcotest.(check string) "IPv4" foo_private (Ipaddr.V4.to_string ipv4);
+    Lwt.return (`Ok ())
+  end with
+  | `Ok () -> ()
+  | `Error (`Msg m) -> failwith m
+
 let test_infra_set = [
   "Server responds correctly", `Quick, test_server;
 ]
 
 let test_forwarder_set = [
   "Zone config respected", `Quick, test_forwarder_zone;
+  "Local names resolve ok", `Quick, test_local_lookups;
 ]
 
 let () =


### PR DESCRIPTION
This patch adds the ability to resolve names locally before forwarding to an upstream resolver. This acts like editing `/etc/hosts` and can be used to override public names with private ones.