### PR TITLE
Split into 2 ocamlfind packages: dns-forward{,.lwt-unix}

### DIFF
--- a/lib/dns-forward-lwt-unix.mllib
+++ b/lib/dns-forward-lwt-unix.mllib
@@ -1,0 +1,1 @@
+Dns_forward_lwt_unix

--- a/lib/dns-forward.mllib
+++ b/lib/dns-forward.mllib
@@ -1,6 +1,5 @@
 Dns_forward
 Dns_forward_config
-Dns_forward_lwt_unix
 Dns_forward_udp
 Dns_forward_tcp
 Dns_forward_error

--- a/pkg/META
+++ b/pkg/META
@@ -1,39 +1,19 @@
-description = "A Git-like database with a filesystem interface"
+description = "A DNS forwarding library"
 version = "%%VERSION%%"
-requires = "lwt logs fmt astring rresult cstruct"
+requires = "lwt logs fmt astring rresult cstruct mirage-flow channel mtime sexplib ipaddr dns"
+archive(byte) = "dns-forward.cma"
+archive(native) = "dns-forward.cmxa"
+plugin(byte) = "dns-forward.cma"
+plugin(native) = "dns-forward.cmxs"
+exists_if = "dns-forward.cma"
 
-package "vfs" (
- directory = "vfs"
- description = "Datakit's VFS description"
+package "lwt-unix" (
+ description = "Lwt_unix I/O library"
  version = "%%VERSION%%"
- requires = ""
- archive(byte) = "vfs.cma"
- archive(native) = "vfs.cmxa"
- plugin(byte) = "vfs.cma"
- plugin(native) = "vfs.cmxs"
- exists_if = "vfs.cma"
-)
-
-package "ivfs" (
- directory = "ivfs"
- description = "Irmin to Datakit's VFS layer"
- version = "%%VERSION%%"
- requires = "irmin datakit.vfs"
- archive(byte) = "ivfs.cma"
- archive(native) = "ivfs.cmxa"
- plugin(byte) = "ivfs.cma"
- plugin(native) = "ivfs.cmxs"
- exists_if = "ivfs.cma"
-)
-
-package "fs9p" (
- directory = "fs9p"
- description = "Datakit's VFS to 9p layer"
- version = "%%VERSION%%"
- requires = "protocol-9p.unix datakit.vfs"
- archive(byte) = "fs9p.cma"
- archive(native) = "fs9p.cmxa"
- plugin(byte) = "fs9p.cma"
- plugin(native) = "fs9p.cmxs"
- exists_if = "fs9p.cma"
+ requires = "lwt.unix lwt logs rresult cstruct cstruct.lwt ipaddr"
+ archive(byte) = "dns-forward-lwt-unix.cma"
+ archive(native) = "dns-forward-lwt-unix.cmxa"
+ plugin(byte) = "dns-forward-lwt-unix.cma"
+ plugin(native) = "dns-forward-lwt-unix.cmxs"
+ exists_if = "dns-forward-lwt-unix.cma"
 )

--- a/pkg/pkg.ml
+++ b/pkg/pkg.ml
@@ -21,6 +21,7 @@ let () =
       Pkg.lib   "pkg/META";
       Pkg.lib   "opam";
       Pkg.mllib "lib/dns-forward.mllib";
+      Pkg.mllib "lib/dns-forward-lwt-unix.mllib";
       Pkg.bin   "bin/main" ~dst:"dns-forwarder";
       Pkg.test  "lib_test/test" ~args:(Cmd.v "-q");
     ]


### PR DESCRIPTION
In particular we'd like to keep the core logix free of Unix and Lwt_unix
so it can be linked into Mirage apps (and apps using `uwt`)

Signed-off-by: David Scott <dave@recoil.org>