### PR TITLE
Add some lower-level modules

### DIFF
--- a/bin/impl.ml
+++ b/bin/impl.ml
@@ -41,10 +41,10 @@ module Time = struct
 end
 
 module Udp = Dns_forward_udp.Make(Dns_forward_lwt_unix.Udp)
-module Udp_forwarder = Dns_forward.Make(Udp)(Udp)(Time)
+module Udp_forwarder = Dns_forward.Make_server(Udp)(Udp)(Time)
 
 module Tcp = Dns_forward_tcp.Make(Dns_forward_lwt_unix.Tcp)(Time)
-module Tcp_forwarder = Dns_forward.Make(Tcp)(Tcp)(Time)
+module Tcp_forwarder = Dns_forward.Make_server(Tcp)(Tcp)(Time)
 
 let max_udp_length = 65507
 
@@ -64,9 +64,9 @@ let serve port filename =
     >>= fun lines ->
     let all = String.concat "" lines in
     let config = Dns_forward_config.t_of_sexp @@ Sexplib.Sexp.of_string all in
-    Udp_forwarder.make config
+    Udp_forwarder.create config
     >>= fun udp ->
-    Tcp_forwarder.make config
+    Tcp_forwarder.create config
     >>= fun tcp ->
     let address = { Dns_forward_config.ip = Ipaddr.V4 Ipaddr.V4.localhost; port } in
     let t =

--- a/lib/dns_forward.ml
+++ b/lib/dns_forward.ml
@@ -62,21 +62,23 @@ let or_fail_msg m = m >>= function
   | `Error (`Msg m) -> Lwt.fail (Failure m)
   | `Ok x -> Lwt.return x
 
-module Make(Server: Dns_forward_s.RPC_SERVER)(Client: Dns_forward_s.RPC_CLIENT)(Time: V1_LWT.TIME) = struct
+module Make_resolver(Client: Dns_forward_s.RPC_CLIENT)(Time: V1_LWT.TIME) = struct
 
   type t = {
     connections: (Dns_forward_config.server * Client.t) list;
-    mutable server: Server.server option;
   }
 
-  let make config =
+  let create config =
     Lwt_list.map_s (fun server ->
       or_fail_msg @@ Client.connect server.Dns_forward_config.address
       >>= fun client ->
       Lwt.return (server, client)
     ) config
     >>= fun connections ->
-    Lwt.return { connections; server = None }
+    Lwt.return { connections }
+
+  let destroy t =
+    Lwt_list.iter_s (fun (_, c) -> Client.disconnect c) t.connections
 
   let answer ?local_names_cb buffer t =
     let len = Cstruct.len buffer in
@@ -127,17 +129,32 @@ module Make(Server: Dns_forward_s.RPC_SERVER)(Client: Dns_forward_s.RPC_CLIENT)(
     | None ->
       Lwt.return (`Error (`Msg "failed to parse request"))
 
+end
+
+module Make_server(Server: Dns_forward_s.RPC_SERVER)(Client: Dns_forward_s.RPC_CLIENT)(Time: V1_LWT.TIME) = struct
+  module Resolver = Make_resolver(Client)(Time)
+
+  type t = {
+    resolver: Resolver.t;
+    mutable server: Server.server option;
+  }
+
+  let create config =
+    Resolver.create config
+    >>= fun resolver ->
+    Lwt.return { resolver; server = None }
+
   let serve ~address ?local_names_cb t =
     let open Dns_forward_error.Infix in
     Server.bind address
     >>= fun server ->
     t.server <- Some server;
-    Server.listen server (fun buf -> answer ?local_names_cb buf t)
+    Server.listen server (fun buf -> Resolver.answer ?local_names_cb buf t.resolver)
     >>= fun () ->
     Lwt.return (`Ok ())
 
-  let shutdown { connections; server } =
-    Lwt_list.iter_s (fun (_, c) -> Client.disconnect c) connections
+  let destroy { resolver; server } =
+    Resolver.destroy resolver
     >>= fun () ->
     match server with
     | None -> Lwt.return_unit

--- a/lib/dns_forward.mli
+++ b/lib/dns_forward.mli
@@ -15,19 +15,32 @@
  *
  *)
 
- module Make(Server: Dns_forward_s.RPC_SERVER)(Client: Dns_forward_s.RPC_CLIENT)(Time: V1_LWT.TIME): sig
+
+module Make_resolver(Client: Dns_forward_s.RPC_CLIENT)(Time: V1_LWT.TIME): sig
 
   type t
-  (** A forwarding DNS proxy *)
+  (** A DNS resolver *)
 
-  val make: Dns_forward_config.t -> t Lwt.t
-  (** Construct a forwarding DNS proxy given some configuration *)
+  val create: Dns_forward_config.t -> t Lwt.t
+  (** Construct a resolver given some configuration *)
 
   val answer:
     ?local_names_cb:(Dns.Packet.question -> Dns.Packet.rr list option Lwt.t) ->
     Cstruct.t ->
     t -> [ `Ok of Cstruct.t | `Error of [ `Msg of string ] ] Lwt.t
-  (** Given a DNS request, construct an response *)
+    (** Given a DNS request, construct an response *)
+
+  val destroy: t -> unit Lwt.t
+  (** Destroy and free all resources associated with the resolver *)
+end
+
+module Make_server(Server: Dns_forward_s.RPC_SERVER)(Client: Dns_forward_s.RPC_CLIENT)(Time: V1_LWT.TIME): sig
+
+  type t
+  (** A forwarding DNS proxy *)
+
+  val create: Dns_forward_config.t -> t Lwt.t
+  (** Construct a forwarding DNS proxy given some configuration *)
 
   val serve:
     address:Dns_forward_config.address ->
@@ -35,6 +48,6 @@
     t -> [ `Ok of unit | `Error of [ `Msg of string ] ] Lwt.t
   (** Serve requests on the given [address] forever *)
 
-  val shutdown: t -> unit Lwt.t
+  val destroy: t -> unit Lwt.t
   (** Shutdown the server and release allocated resources *)
- end
+end

--- a/lib/dns_forward.mli
+++ b/lib/dns_forward.mli
@@ -17,18 +17,12 @@
 
 
 module Make_resolver(Client: Dns_forward_s.RPC_CLIENT)(Time: V1_LWT.TIME): sig
+  (** A simple DNS resolver *)
 
-  type t
-  (** A DNS resolver *)
+  include Dns_forward_s.RESOLVER
 
   val create: Dns_forward_config.t -> t Lwt.t
   (** Construct a resolver given some configuration *)
-
-  val answer:
-    ?local_names_cb:(Dns.Packet.question -> Dns.Packet.rr list option Lwt.t) ->
-    Cstruct.t ->
-    t -> [ `Ok of Cstruct.t | `Error of [ `Msg of string ] ] Lwt.t
-    (** Given a DNS request, construct an response *)
 
   val destroy: t -> unit Lwt.t
   (** Destroy and free all resources associated with the resolver *)

--- a/lib/dns_forward.mli
+++ b/lib/dns_forward.mli
@@ -39,6 +39,7 @@ module Make_server(Server: Dns_forward_s.RPC_SERVER)(Client: Dns_forward_s.RPC_C
   val serve:
     address:Dns_forward_config.address ->
     ?local_names_cb:(Dns.Packet.question -> Dns.Packet.rr list option Lwt.t) ->
+    ?timeout:float ->
     t -> [ `Ok of unit | `Error of [ `Msg of string ] ] Lwt.t
   (** Serve requests on the given [address] forever *)
 

--- a/lib/dns_forward_lwt_unix.mli
+++ b/lib/dns_forward_lwt_unix.mli
@@ -15,5 +15,5 @@
  *
  *)
 
-module Tcp: Dns_forward_s.TCPIP
-module Udp: Dns_forward_s.TCPIP
+module Tcp: Dns_forward_s.SOCKETS
+module Udp: Dns_forward_s.SOCKETS

--- a/lib/dns_forward_s.mli
+++ b/lib/dns_forward_s.mli
@@ -81,3 +81,11 @@ module type RPC_SERVER = sig
   val listen: server -> (request -> [ `Ok of response | `Error of [ `Msg of string ] ] Lwt.t) -> [`Ok of unit | `Error of [ `Msg of string ]] Lwt.t
   val shutdown: server -> unit Lwt.t
 end
+
+module type RESOLVER = sig
+  type t
+  val answer:
+    ?local_names_cb:(Dns.Packet.question -> Dns.Packet.rr list option Lwt.t) ->
+    Cstruct.t ->
+    t -> [ `Ok of Cstruct.t | `Error of [ `Msg of string ] ] Lwt.t
+end

--- a/lib/dns_forward_s.mli
+++ b/lib/dns_forward_s.mli
@@ -48,7 +48,7 @@ module type FLOW_SERVER = sig
   (** Stop accepting connections on the given server *)
 end
 
-module type TCPIP = sig
+module type SOCKETS = sig
   type address = Ipaddr.t * int
 
   type flow

--- a/lib/dns_forward_s.mli
+++ b/lib/dns_forward_s.mli
@@ -86,6 +86,7 @@ module type RESOLVER = sig
   type t
   val answer:
     ?local_names_cb:(Dns.Packet.question -> Dns.Packet.rr list option Lwt.t) ->
+    ?timeout:float ->
     Cstruct.t ->
     t -> [ `Ok of Cstruct.t | `Error of [ `Msg of string ] ] Lwt.t
 end

--- a/lib/dns_forward_s.mli
+++ b/lib/dns_forward_s.mli
@@ -89,3 +89,12 @@ module type RESOLVER = sig
     Cstruct.t ->
     t -> [ `Ok of Cstruct.t | `Error of [ `Msg of string ] ] Lwt.t
 end
+
+module type READERWRITER = sig
+  (** Read and write DNS packets from a flow *)
+  type request = Cstruct.t
+  type response = Cstruct.t
+  type t
+  val read: t -> [ `Ok of request | `Error of [ `Msg of string ] ] Lwt.t
+  val write: t -> response -> [ `Ok of unit | `Error of [ `Msg of string ] ] Lwt.t
+end

--- a/lib/dns_forward_tcp.ml
+++ b/lib/dns_forward_tcp.ml
@@ -96,7 +96,7 @@ module ReaderWriter(Flow: V1_LWT.FLOW) = struct
       )
 end
 
-module Make(Tcp: Dns_forward_s.TCPIP)(Time: V1_LWT.TIME) = struct
+module Make(Tcp: Dns_forward_s.SOCKETS)(Time: V1_LWT.TIME) = struct
   type address = Dns_forward_config.address
 
   module RW = ReaderWriter(Tcp)

--- a/lib/dns_forward_tcp.ml
+++ b/lib/dns_forward_tcp.ml
@@ -24,32 +24,102 @@ module Log = (val Logs.src_log src : Logs.LOG)
 
 module IntSet = Set.Make(struct type t = int let compare (a: int) (b: int) = compare a b end)
 
+module ReaderWriter(Flow: V1_LWT.FLOW) = struct
+  module Error = Dns_forward_error.Infix
+  let errorf = Dns_forward_error.errorf
+
+  module C = Channel.Make(Flow)
+
+  type request = Cstruct.t
+  type response = Cstruct.t
+  type t = {
+    c: C.t;
+    write_m: Lwt_mutex.t;
+    read_m: Lwt_mutex.t;
+  }
+
+  let connect flow =
+    let c = C.create flow in
+    let write_m = Lwt_mutex.create () in
+    let read_m = Lwt_mutex.create () in
+    { c; write_m; read_m }
+
+  let close t =
+    Flow.close @@ C.to_flow t.c
+
+  let read t =
+    Lwt_mutex.with_lock t.read_m
+      (fun () ->
+        let open Error in
+        Lwt.catch
+          (fun () ->
+            let open Lwt.Infix in
+            C.read_exactly ~len:2 t.c
+            >>= fun bufs ->
+            Lwt.return (`Ok bufs)
+          ) (fun e ->
+            errorf "Failed to read response header: %s" (Printexc.to_string e)
+          )
+        >>= fun bufs ->
+        let buf = Cstruct.concat bufs in
+        let len = Cstruct.BE.get_uint16 buf 0 in
+        Lwt.catch
+          (fun () ->
+            let open Lwt.Infix in
+            C.read_exactly ~len t.c
+            >>= fun bufs ->
+            Lwt.return (`Ok bufs)
+          ) (fun e ->
+            errorf "Failed to read response payload (%d bytes): %s" len (Printexc.to_string e)
+          )
+        >>= fun bufs ->
+        Lwt.return (`Ok (Cstruct.concat bufs))
+      )
+
+  let write t buffer =
+    Lwt_mutex.with_lock t.write_m
+      (fun () ->
+        (* RFC 1035 4.2.2 TCP Usage: 2 byte length field *)
+        let header = Cstruct.create 2 in
+        Cstruct.BE.set_uint16 header 0 (Cstruct.len buffer);
+        C.write_buffer t.c header;
+        C.write_buffer t.c buffer;
+        Lwt.catch
+          (fun () ->
+            let open Lwt.Infix in
+            C.flush t.c
+            >>= fun () ->
+            Lwt.return (`Ok ())
+          ) (fun e ->
+            errorf "Failed to write %d bytes: %s" (Cstruct.len buffer) (Printexc.to_string e)
+          )
+      )
+end
+
 module Make(Tcp: Dns_forward_s.TCPIP)(Time: V1_LWT.TIME) = struct
   type address = Dns_forward_config.address
 
-  module C = Channel.Make(Tcp)
+  module RW = ReaderWriter(Tcp)
 
   type t = {
     address: address;
-    mutable c: C.t option;
+    mutable rw: RW.t option;
     mutable disconnect_on_idle: unit Lwt.t;
     wakeners: (int, [ `Ok of Cstruct.t | `Error of [ `Msg of string ] ] Lwt.u) Hashtbl.t;
     m: Lwt_mutex.t;
-    write_m: Lwt_mutex.t;
     mutable free_ids: IntSet.t;
     free_ids_c: unit Lwt_condition.t;
   }
 
   module Error = Dns_forward_error.Infix
   module FlowError = Dns_forward_error.FromFlowError(Tcp)
-  let errorf = Dns_forward_error.errorf
 
   let disconnect t =
     Lwt_mutex.with_lock t.m
       (fun () ->
         match t with
-        | { c = Some c; _ } as t ->
-          t.c <- None;
+        | { rw = Some rw; _ } as t ->
+          t.rw <- None;
           let tbl = Hashtbl.copy t.wakeners in
           Hashtbl.clear t.wakeners;
           let error = `Error (`Msg "connection to server was closed") in
@@ -58,42 +128,16 @@ module Make(Tcp: Dns_forward_s.TCPIP)(Time: V1_LWT.TIME) = struct
             t.free_ids <- IntSet.add id t.free_ids;
             Lwt.wakeup_later u error
           ) tbl;
-          Tcp.close @@ C.to_flow c
+          RW.close rw
         | _ -> Lwt.return_unit
       )
 
-  let read_buffer c =
-    let open Error in
-    Lwt.catch
-      (fun () ->
-        let open Lwt.Infix in
-        C.read_exactly ~len:2 c
-        >>= fun bufs ->
-        Lwt.return (`Ok bufs)
-      ) (fun e ->
-        errorf "Failed to read response header: %s" (Printexc.to_string e)
-      )
-    >>= fun bufs ->
-    let buf = Cstruct.concat bufs in
-    let len = Cstruct.BE.get_uint16 buf 0 in
-    Lwt.catch
-      (fun () ->
-        let open Lwt.Infix in
-        C.read_exactly ~len c
-        >>= fun bufs ->
-        Lwt.return (`Ok bufs)
-      ) (fun e ->
-        errorf "Failed to read response payload (%d bytes): %s" len (Printexc.to_string e)
-      )
-    >>= fun bufs ->
-    Lwt.return (`Ok (Cstruct.concat bufs))
-
   (* Receive all the responses and demux to the right thread. When the connection
      is closed, `read_buffer` will fail and this thread will exit. *)
-  let dispatcher t c () =
+  let dispatcher t rw () =
     let open Lwt.Infix in
     let rec loop () =
-      read_buffer c
+      RW.read rw
       >>= function
       | `Error (`Msg m) ->
         Log.info (fun f -> f "%s: dispatcher shutting down" m);
@@ -123,57 +167,40 @@ module Make(Tcp: Dns_forward_s.TCPIP)(Time: V1_LWT.TIME) = struct
         Lwt.return_unit
       )
 
-  let get_c t =
+  let get_rw t =
     let open Error in
     Lwt.cancel t.disconnect_on_idle;
     Lwt_mutex.with_lock t.m
-      (fun () -> match t.c with
+      (fun () -> match t.rw with
         | None ->
           Tcp.connect (t.address.Dns_forward_config.ip, t.address.Dns_forward_config.port)
           >>= fun flow ->
-          let c = C.create flow in
-          t.c <- Some c;
-          Lwt.async (dispatcher t c);
-          Lwt.return (`Ok c)
-        | Some c ->
-          Lwt.return (`Ok c))
-    >>= fun c ->
+          let rw = RW.connect flow in
+          t.rw <- Some rw;
+          Lwt.async (dispatcher t rw);
+          Lwt.return (`Ok rw)
+        | Some rw ->
+          Lwt.return (`Ok rw))
+    >>= fun rw ->
     (* Add a fresh idle timer *)
     t.disconnect_on_idle <- (let open Lwt.Infix in Time.sleep 30. >>= fun () -> disconnect t);
-    Lwt.return (`Ok c)
+    Lwt.return (`Ok rw)
 
   type request = Cstruct.t
   type response = Cstruct.t
 
   let connect address =
-    let c = None in
+    let rw = None in
     let m = Lwt_mutex.create () in
     let disconnect_on_idle = Lwt.return_unit in
     let wakeners = Hashtbl.create 7 in
-    let write_m = Lwt_mutex.create () in
     let free_ids =
       let rec loop acc = function
         | 0 -> acc
         | n -> loop (IntSet.add n acc) (n - 1) in
       loop IntSet.empty 512 in
     let free_ids_c = Lwt_condition.create () in
-    Lwt.return (`Ok { address; c; disconnect_on_idle; wakeners; m; write_m; free_ids; free_ids_c })
-
-  let write_buffer c buffer =
-    (* RFC 1035 4.2.2 TCP Usage: 2 byte length field *)
-    let header = Cstruct.create 2 in
-    Cstruct.BE.set_uint16 header 0 (Cstruct.len buffer);
-    C.write_buffer c header;
-    C.write_buffer c buffer;
-    Lwt.catch
-      (fun () ->
-        let open Lwt.Infix in
-        C.flush c
-        >>= fun () ->
-        Lwt.return (`Ok ())
-      ) (fun e ->
-        errorf "Failed to write %d bytes: %s" (Cstruct.len buffer) (Printexc.to_string e)
-      )
+    Lwt.return (`Ok { address; rw; disconnect_on_idle; wakeners; m; free_ids; free_ids_c })
 
   let rpc (t: t) buffer =
     let buf = Dns.Buf.of_cstruct buffer in
@@ -213,12 +240,12 @@ module Make(Tcp: Dns_forward_s.TCPIP)(Time: V1_LWT.TIME) = struct
       let open Lwt.Infix in
       begin
         let open Error in
-        get_c t
-        >>= fun c ->
+        get_rw t
+        >>= fun rw ->
         let open Lwt.Infix in
         (* An existing connection to the server might have been closed by the server;
            therefore if we fail to write the request, reconnect and try once more. *)
-        Lwt_mutex.with_lock t.write_m (fun () -> write_buffer c buffer)
+        RW.write rw buffer
         >>= function
         | `Ok () ->
           Lwt.return (`Ok ())
@@ -227,9 +254,9 @@ module Make(Tcp: Dns_forward_s.TCPIP)(Time: V1_LWT.TIME) = struct
           disconnect t
           >>= fun () ->
           let open Error in
-          get_c t
-          >>= fun c ->
-          Lwt_mutex.with_lock t.write_m (fun () -> write_buffer c buffer)
+          get_rw t
+          >>= fun rw ->
+          RW.write rw buffer
       end
       >>= function
       | `Error (`Msg m) ->
@@ -257,10 +284,10 @@ module Make(Tcp: Dns_forward_s.TCPIP)(Time: V1_LWT.TIME) = struct
   let listen { server; _ } cb =
     Tcp.listen server (fun flow ->
       let open Lwt.Infix in
-      let c = C.create flow in
+      let rw = RW.connect flow in
       let rec loop () =
         let open Error in
-        read_buffer c
+        RW.read rw
         >>= fun request ->
         (* FIXME: need to run these in the background *)
         (* FIXME: need to rewrite transaction IDs if the requests come from
@@ -272,7 +299,7 @@ module Make(Tcp: Dns_forward_s.TCPIP)(Time: V1_LWT.TIME) = struct
           loop ()
         | `Ok response ->
           let open Error in
-          write_buffer c response
+          RW.write rw response
           >>= fun () ->
           loop () in
       loop ()

--- a/lib/dns_forward_tcp.mli
+++ b/lib/dns_forward_tcp.mli
@@ -17,6 +17,12 @@
 
 (** DNS over TCP uses a simple header to delineate message boundaries *)
 
+module ReaderWriter(Flow: V1_LWT.FLOW): sig
+  include Dns_forward_s.READERWRITER
+
+  val connect: Flow.flow -> t
+end
+
 module Make(Tcp: Dns_forward_s.TCPIP)(Time: V1_LWT.TIME): sig
   type request = Cstruct.t
   type response = Cstruct.t

--- a/lib/dns_forward_tcp.mli
+++ b/lib/dns_forward_tcp.mli
@@ -23,7 +23,7 @@ module ReaderWriter(Flow: V1_LWT.FLOW): sig
   val connect: Flow.flow -> t
 end
 
-module Make(Tcp: Dns_forward_s.TCPIP)(Time: V1_LWT.TIME): sig
+module Make(Tcp: Dns_forward_s.SOCKETS)(Time: V1_LWT.TIME): sig
   type request = Cstruct.t
   type response = Cstruct.t
   type address = Dns_forward_config.address

--- a/lib/dns_forward_udp.ml
+++ b/lib/dns_forward_udp.ml
@@ -22,7 +22,7 @@ let src =
 
 module Log = (val Logs.src_log src : Logs.LOG)
 
-module Make(Udp: Dns_forward_s.TCPIP) = struct
+module Make(Udp: Dns_forward_s.SOCKETS) = struct
   type address = Dns_forward_config.address
 
   type t = {

--- a/lib/dns_forward_udp.mli
+++ b/lib/dns_forward_udp.mli
@@ -17,7 +17,7 @@
 
 (** DNS over UDP uses the UDP datagrams to delineate message boundaries *)
 
-module Make(Udp: Dns_forward_s.TCPIP): sig
+module Make(Udp: Dns_forward_s.SOCKETS): sig
   type request = Cstruct.t
   type response = Cstruct.t
   type address = Dns_forward_config.address

--- a/lib_test/flow.mli
+++ b/lib_test/flow.mli
@@ -17,7 +17,7 @@
 
 (** An in-memory FLOW simulation *)
 
-include Dns_forward_s.TCPIP
+include Dns_forward_s.SOCKETS
 
 val get_connections: unit -> (address * int) list
 (** Return a list of [server address, number of clients still connected] *)

--- a/lib_test/test.ml
+++ b/lib_test/test.ml
@@ -79,13 +79,13 @@ let test_forwarder_zone () =
     S.serve ~address:bar_address bar_server
     >>= fun () ->
     (* a forwarder which uses both servers *)
-    let module F = Dns_forward.Make(Rpc)(Rpc)(Time) in
+    let module F = Dns_forward.Make_server(Rpc)(Rpc)(Time) in
     let config = [
       { Dns_forward_config.address = foo_address; zones = [ [ "foo" ] ] };
       { Dns_forward_config.address = bar_address; zones = [] }
     ] in
     let open Lwt.Infix in
-    F.make config
+    F.create config
     >>= fun f ->
     let f_address = { Dns_forward_config.ip = Ipaddr.V4 Ipaddr.V4.localhost; port = 3 } in
     let open Error in
@@ -102,7 +102,7 @@ let test_forwarder_zone () =
     let open Lwt.Infix in
     Rpc.disconnect c
     >>= fun () ->
-    F.shutdown f
+    F.destroy f
     >>= fun () ->
     Lwt.return (`Ok ())
   end with
@@ -126,12 +126,12 @@ let test_local_lookups () =
     let open Error in
     S.serve ~address:public_address public_server
     >>= fun () ->
-    let module F = Dns_forward.Make(Rpc)(Rpc)(Time) in
+    let module F = Dns_forward.Make_server(Rpc)(Rpc)(Time) in
     let config = [
       { Dns_forward_config.address = public_address; zones = [] };
     ] in
     let open Lwt.Infix in
-    F.make config
+    F.create config
     >>= fun f ->
     let f_address = { Dns_forward_config.ip = Ipaddr.V4 Ipaddr.V4.localhost; port = 5 } in
     let local_names_cb question =
@@ -157,7 +157,7 @@ let test_local_lookups () =
     let open Lwt.Infix in
     Rpc.disconnect c
     >>= fun () ->
-    F.shutdown f
+    F.destroy f
     >>= fun () ->
     Lwt.return (`Ok ())
   end with
@@ -177,12 +177,12 @@ let test_tcp_multiplexing () =
     let open Error in
     S.serve ~address:public_address public_server
     >>= fun () ->
-    let module F = Dns_forward.Make(Proto)(Proto)(Time) in
+    let module F = Dns_forward.Make_server(Proto)(Proto)(Time) in
     let config = [
       { Dns_forward_config.address = public_address; zones = [] };
     ] in
     let open Lwt.Infix in
-    F.make config
+    F.create config
     >>= fun f ->
     let f_address = { Dns_forward_config.ip = Ipaddr.V4 Ipaddr.V4.localhost; port = 7 } in
     let open Error in
@@ -218,7 +218,7 @@ let test_tcp_multiplexing () =
     let open Lwt.Infix in
     Proto.disconnect c
     >>= fun () ->
-    F.shutdown f
+    F.destroy f
     >>= fun () ->
     Lwt.return (`Ok ())
   end with


### PR DESCRIPTION
This PR adds

- a `READERWRITER` interface and a TCP implementation which handles the message framing
- a `RESOLVER` interface which can be used to answer DNS questions

We should be able to receive requests from a FLOW, resolve them and reply without having to implement any of the `*_SERVER` signatures.