### PR TITLE
Use an Lwt_result.t compatible API

### DIFF
--- a/bin/impl.ml
+++ b/bin/impl.ml
@@ -67,7 +67,7 @@ let serve port filename =
     >>= fun tcp ->
     let address = { Config.ip = Ipaddr.V4 Ipaddr.V4.localhost; port } in
     let t =
-      let open Error.Lwt.Infix in
+      let open Error.Infix in
       Server.Udp.serve ~address udp
       >>= fun () ->
       Server.Tcp.serve ~address tcp
@@ -75,6 +75,6 @@ let serve port filename =
       let t, _ = Lwt.task () in
       t in
     t >>= function
-    | `Error (`Msg m) -> Lwt.return (`Error(true, m))
-    | `Ok () -> Lwt.return (`Ok ())
+    | Result.Error (`Msg m) -> Lwt.return (`Error(true, m))
+    | Result.Ok () -> Lwt.return (`Ok ())
   end

--- a/lib/dns-forward.mllib
+++ b/lib/dns-forward.mllib
@@ -8,3 +8,4 @@ Dns_forward_server
 Dns_forward_framing
 Dns_forward_flow
 Dns_forward_s
+Dns_forward_lwt_result

--- a/lib/dns_forward_error.ml
+++ b/lib/dns_forward_error.ml
@@ -16,23 +16,15 @@
  *)
 open Lwt.Infix
 
-type 'a t = [ `Ok of 'a | `Error of [ `Msg of string ] ]
+type 'a t = ('a, [ `Msg of string ]) Dns_forward_lwt_result.t
 
 module FromFlowError(Flow: V1_LWT.FLOW) = struct
   let (>>=) m f = m >>= function
-    | `Eof -> Lwt.return (`Error (`Msg "Unexpected end of file"))
-    | `Error e -> Lwt.return (`Error (`Msg (Flow.error_message e)))
+    | `Eof -> Lwt.return (Result.Error (`Msg "Unexpected end of file"))
+    | `Error e -> Lwt.return (Result.Error (`Msg (Flow.error_message e)))
     | `Ok x -> f x
 end
 
-let errorf fmt = Printf.ksprintf (fun s -> Lwt.return (`Error (`Msg s))) fmt
+let errorf fmt = Printf.ksprintf (fun s -> Lwt.return (Result.Error (`Msg s))) fmt
 
-module L = Lwt
-
-module Lwt = struct
-  module Infix = struct
-    let (>>=) m f = m >>= function
-      | `Error (`Msg m) -> L.return (`Error (`Msg m))
-      | `Ok x -> f x
-  end
-end
+module Infix = Dns_forward_lwt_result.Infix

--- a/lib/dns_forward_error.mli
+++ b/lib/dns_forward_error.mli
@@ -15,20 +15,15 @@
  *
  *)
 
-type 'a t = [ `Ok of 'a | `Error of [ `Msg of string ] ]
+type 'a t = ('a, [ `Msg of string ]) Dns_forward_lwt_result.t
 
 module FromFlowError(Flow: V1_LWT.FLOW): sig
-  val (>>=): [< `Eof | `Error of Flow.error | `Ok of 'b ] Lwt.t ->
-    ('b -> ([> `Error of [> `Msg of string ] ] as 'c) Lwt.t) -> 'c Lwt.t
-
+  val ( >>= ) : [< `Eof | `Error of Flow.error | `Ok of 'b ] Lwt.t ->
+    ('b -> ('c, [> `Msg of string ] as 'd) result Lwt.t) -> ('c, 'd) result Lwt.t
 end
 
-val errorf: ('a, unit, string, [> `Error of [> `Msg of string ] ] Lwt.t) format4 -> 'a
+val errorf: ('a, unit, string, ('b, [> `Msg of string ]) result Lwt.t) format4 -> 'a
 
-
-module Lwt: sig
 module Infix: sig
-  val (>>=): [< `Error of [< `Msg of 'a ] | `Ok of 'b ] Lwt.t ->
-    ('b -> ([> `Error of [> `Msg of 'a ] ] as 'c) Lwt.t) -> 'c Lwt.t
-end
+  include module type of Dns_forward_lwt_result.Infix
 end

--- a/lib/dns_forward_lwt_result.ml
+++ b/lib/dns_forward_lwt_result.ml
@@ -1,0 +1,28 @@
+(*
+ * Copyright (C) 2016 David Scott <dave@recoil.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ *)
+open Lwt.Infix
+
+type ('a, 'b) t = ('a, 'b) Result.result Lwt.t
+
+let return x = Lwt.return (Result.Ok x)
+let fail   y = Lwt.return (Result.Error y)
+
+module Infix = struct
+  let (>>=) m f = m >>= function
+    | Result.Error y -> Lwt.return (Result.Error y)
+    | Result.Ok x -> f x
+end

--- a/lib/dns_forward_lwt_result.mli
+++ b/lib/dns_forward_lwt_result.mli
@@ -1,0 +1,29 @@
+(*
+ * Copyright (C) 2016 David Scott <dave@recoil.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ *)
+
+(** The same error type is supported in Lwt > 2.5.2. Once that is released we
+    can remove this shim. *)
+
+type ('a, 'b) t = ('a, 'b) Result.result Lwt.t
+
+val return : 'a -> ('a, 'b) t
+
+val fail : 'b -> ('a, 'b) t
+
+module Infix: sig
+  val (>>=): ('a, 'e) t -> ('a -> ('b, 'e) t) -> ('b, 'e) t
+end

--- a/lib/dns_forward_lwt_unix.ml
+++ b/lib/dns_forward_lwt_unix.ml
@@ -40,7 +40,7 @@ module Common = struct
   let error_message = function
    | `Msg x -> x
 
-  let errorf fmt = Printf.ksprintf (fun s -> Lwt.return (`Error (`Msg s))) fmt
+  let errorf fmt = Printf.ksprintf (fun s -> Lwt.return (Result.Error (`Msg s))) fmt
 
   type address = Ipaddr.t * int
 
@@ -96,7 +96,7 @@ module Tcp = struct
       (fun () ->
          Lwt_unix.connect fd sockaddr
          >>= fun () ->
-         Lwt.return (`Ok (of_fd ~read_buffer_size address fd))
+         Lwt.return (Result.Ok (of_fd ~read_buffer_size address fd))
       )
       (fun e ->
          Lwt_unix.close fd
@@ -215,7 +215,7 @@ module Tcp = struct
       (fun () ->
         Lwt_unix.setsockopt fd Lwt_unix.SO_REUSEADDR true;
         Lwt_unix.bind fd (sockaddr_of_address address);
-        Lwt.return (`Ok { server_fd = Some fd; read_buffer_size = default_read_buffer_size; address })
+        Lwt.return (Result.Ok { server_fd = Some fd; read_buffer_size = default_read_buffer_size; address })
       ) (fun e ->
         Lwt_unix.close fd
         >>= fun () ->
@@ -319,7 +319,7 @@ module Udp = struct
     (* Win32 requires all sockets to be bound however macOS and Linux don't *)
     (try Lwt_unix.bind fd (Lwt_unix.ADDR_INET(Unix.inet_addr_any, 0)) with _ -> ());
     let sockaddr = sockaddr_of_address address in
-    Lwt.return (`Ok (of_fd ?read_buffer_size sockaddr address fd))
+    Lwt.return (Result.Ok (of_fd ?read_buffer_size sockaddr address fd))
 
   let read t = match t.fd, t.already_read with
     | None, _ -> Lwt.return `Eof
@@ -393,7 +393,7 @@ module Udp = struct
     try
       let sockaddr = sockaddr_of_address address in
       Lwt_unix.bind fd sockaddr;
-      Lwt.return (`Ok { server_fd = Some fd; address })
+      Lwt.return (Result.Ok { server_fd = Some fd; address })
     with
     | e -> errorf "udp:%s: bind caught %s"
       (string_of_address address) (Printexc.to_string e)

--- a/lib/dns_forward_rpc.ml
+++ b/lib/dns_forward_rpc.ml
@@ -14,6 +14,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
  *)
+module Lwt_result = Dns_forward_lwt_result (* remove when this is available *)
 
 let src =
   let src = Logs.Src.create "Dns_forward" ~doc:"DNS over SOCKETS" in
@@ -21,8 +22,6 @@ let src =
   src
 
 module Log = (val Logs.src_log src : Logs.LOG)
-
-module Error = Dns_forward_error.Lwt.Infix
 
 module Client = struct
 
@@ -40,7 +39,7 @@ module Client = struct
       address: address;
       mutable rw: Packet.t option;
       mutable disconnect_on_idle: unit Lwt.t;
-      wakeners: (int, [ `Ok of Cstruct.t | `Error of [ `Msg of string ] ] Lwt.u) Hashtbl.t;
+      wakeners: (int, (Cstruct.t, [ `Msg of string ]) Result.result Lwt.u) Hashtbl.t;
       m: Lwt_mutex.t;
       free_ids: Dns_forward_free_id.t;
     }
@@ -55,7 +54,7 @@ module Client = struct
             t.rw <- None;
             let tbl = Hashtbl.copy t.wakeners in
             Hashtbl.clear t.wakeners;
-            let error = `Error (`Msg "connection to server was closed") in
+            let error = Result.Error (`Msg "connection to server was closed") in
             Hashtbl.iter (fun id u ->
               Log.err (fun f -> f "disconnect: failing request with id %d" id);
               Dns_forward_free_id.put t.free_ids id;
@@ -72,10 +71,10 @@ module Client = struct
       let rec loop () =
         Packet.read rw
         >>= function
-        | `Error (`Msg m) ->
+        | Result.Error (`Msg m) ->
           Log.info (fun f -> f "%s: dispatcher shutting down" m);
           disconnect t
-        | `Ok buffer ->
+        | Result.Ok buffer ->
           let buf = Dns.Buf.of_cstruct buffer in
           begin match Dns.Protocol.Server.parse (Dns.Buf.sub buf 0 (Cstruct.len buffer)) with
           | None ->
@@ -87,7 +86,7 @@ module Client = struct
               let u = Hashtbl.find t.wakeners client_id in
               Hashtbl.remove t.wakeners client_id;
               Dns_forward_free_id.put t.free_ids client_id;
-              Lwt.wakeup_later u (`Ok buffer)
+              Lwt.wakeup_later u (Result.Ok buffer)
             end else begin
               Log.err (fun f -> f "failed to find a wakener for id %d" client_id);
             end;
@@ -101,7 +100,7 @@ module Client = struct
         )
 
     let get_rw t =
-      let open Error in
+      let open Lwt_result.Infix in
       Lwt.cancel t.disconnect_on_idle;
       Lwt_mutex.with_lock t.m
         (fun () -> match t.rw with
@@ -111,13 +110,13 @@ module Client = struct
             let rw = Packet.connect flow in
             t.rw <- Some rw;
             Lwt.async (dispatcher t rw);
-            Lwt.return (`Ok rw)
+            Lwt_result.return rw
           | Some rw ->
-            Lwt.return (`Ok rw))
+            Lwt_result.return rw)
       >>= fun rw ->
       (* Add a fresh idle timer *)
       t.disconnect_on_idle <- (let open Lwt.Infix in Time.sleep 30. >>= fun () -> disconnect t);
-      Lwt.return (`Ok rw)
+      Lwt_result.return rw
 
     let connect address =
       let rw = None in
@@ -125,14 +124,14 @@ module Client = struct
       let disconnect_on_idle = Lwt.return_unit in
       let wakeners = Hashtbl.create 7 in
       let free_ids = Dns_forward_free_id.make () in
-      Lwt.return (`Ok { address; rw; disconnect_on_idle; wakeners; m; free_ids })
+      Lwt_result.return { address; rw; disconnect_on_idle; wakeners; m; free_ids }
 
     let rpc (t: t) buffer =
       let buf = Dns.Buf.of_cstruct buffer in
       match Dns.Protocol.Server.parse (Dns.Buf.sub buf 0 (Cstruct.len buffer)) with
       | None ->
         Log.err (fun f -> f "failed to parse request");
-        Lwt.return (`Error (`Msg "failed to parse request"))
+        Lwt_result.fail (`Msg "failed to parse request")
       | Some request ->
         (* Note: the received request id is scoped to the connection with the
            client. Since we are multiplexing requests to a single server we need
@@ -154,7 +153,7 @@ module Client = struct
         (* If we fail to connect, return the error *)
         let open Lwt.Infix in
         begin
-          let open Error in
+          let open Lwt_result.Infix in
           get_rw t
           >>= fun rw ->
           let open Lwt.Infix in
@@ -162,29 +161,29 @@ module Client = struct
              therefore if we fail to write the request, reconnect and try once more. *)
           Packet.write rw buffer
           >>= function
-          | `Ok () ->
-            Lwt.return (`Ok ())
-          | `Error (`Msg m) ->
+          | Result.Ok () ->
+            Lwt_result.return ()
+          | Result.Error (`Msg m) ->
             Log.info (fun f -> f "caught %s writing request, attempting to reconnect" m);
             disconnect t
             >>= fun () ->
-            let open Error in
+            let open Lwt_result.Infix in
             get_rw t
             >>= fun rw ->
             Packet.write rw buffer
         end
         >>= function
-        | `Error (`Msg m) ->
+        | Result.Error (`Msg m) ->
           Hashtbl.remove t.wakeners free_id;
           Dns_forward_free_id.put t.free_ids free_id;
-          Lwt.return (`Error (`Msg m))
-        | `Ok () ->
-          let open Error in
+          Lwt_result.fail (`Msg m)
+        | Result.Ok () ->
+          let open Lwt_result.Infix in
           th (* will be woken up by the dispatcher *)
           >>= fun buf ->
           (* Rewrite the query id back to the original *)
           Cstruct.BE.set_uint16 buf 0 client_id;
-          Lwt.return (`Ok buf)
+          Lwt_result.return buf
   end
 end
 
@@ -206,17 +205,17 @@ module Server = struct
     }
 
     let bind address =
-      let open Error in
+      let open Lwt_result.Infix in
       Sockets.bind (address.Dns_forward_config.ip, address.Dns_forward_config.port)
       >>= fun server ->
-      Lwt.return (`Ok { address; server })
+      Lwt_result.return { address; server }
 
     let listen { server; _ } cb =
       Sockets.listen server (fun flow ->
         let open Lwt.Infix in
         let rw = Packet.connect flow in
         let rec loop () =
-          let open Error in
+          let open Lwt_result.Infix in
           Packet.read rw
           >>= fun request ->
           (* FIXME: need to run these in the background *)
@@ -225,22 +224,22 @@ module Server = struct
           let open Lwt.Infix in
           cb request
           >>= function
-          | `Error _ ->
+          | Result.Error _ ->
             loop ()
-          | `Ok response ->
-            let open Error in
+          | Result.Ok response ->
+            let open Lwt_result.Infix in
             Packet.write rw response
             >>= fun () ->
             loop () in
         loop ()
         >>= function
-        | `Error (`Msg m) ->
+        | Result.Error (`Msg m) ->
           Log.err (fun f -> f "server loop failed with: %s" m);
           Lwt.return_unit
-        | `Ok () ->
+        | Result.Ok () ->
           Lwt.return_unit
       );
-      Lwt.return (`Ok ())
+      Lwt_result.return ()
 
     let shutdown server =
       Sockets.shutdown server.server

--- a/lib/dns_forward_s.ml
+++ b/lib/dns_forward_s.ml
@@ -14,18 +14,19 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
  *)
+module Lwt_result = Dns_forward_lwt_result (* remove when this is available *)
 
 module type FLOW_CLIENT = sig
   include Mirage_flow_s.SHUTDOWNABLE
   type address
   val connect: ?read_buffer_size:int -> address
-    -> [ `Ok of flow | `Error of [ `Msg of string ] ] Lwt.t
+    -> (flow, [ `Msg of string ]) Lwt_result.t
 end
 
 module type FLOW_SERVER = sig
   type server
   type address
-  val bind: address -> [ `Ok of server | `Error of [ `Msg of string ]] Lwt.t
+  val bind: address -> (server, [ `Msg of string ]) Lwt_result.t
   val getsockname: server -> address
   type flow
   val listen: server -> (flow -> unit Lwt.t) -> unit
@@ -50,8 +51,8 @@ module type RPC_CLIENT = sig
   type response = Cstruct.t
   type address = Dns_forward_config.address
   type t
-  val connect: address -> [ `Ok of t | `Error of [ `Msg of string ] ] Lwt.t
-  val rpc: t -> request -> [ `Ok of response | `Error of [ `Msg of string ] ] Lwt.t
+  val connect: address -> (t, [ `Msg of string ]) Lwt_result.t
+  val rpc: t -> request -> (response, [ `Msg of string ]) Lwt_result.t
   val disconnect: t -> unit Lwt.t
 end
 
@@ -61,8 +62,8 @@ module type RPC_SERVER = sig
   type address = Dns_forward_config.address
 
   type server
-  val bind: address -> [ `Ok of server | `Error of [ `Msg of string ] ] Lwt.t
-  val listen: server -> (request -> [ `Ok of response | `Error of [ `Msg of string ] ] Lwt.t) -> [`Ok of unit | `Error of [ `Msg of string ]] Lwt.t
+  val bind: address -> (server, [ `Msg of string ]) Lwt_result.t
+  val listen: server -> (request -> (response, [ `Msg of string ]) Lwt_result.t) -> (unit, [ `Msg of string ]) Lwt_result.t
   val shutdown: server -> unit Lwt.t
 end
 
@@ -74,7 +75,7 @@ module type RESOLVER = sig
     ?local_names_cb:(Dns.Packet.question -> Dns.Packet.rr list option Lwt.t) ->
     ?timeout:float ->
     Cstruct.t ->
-    t -> [ `Ok of Cstruct.t | `Error of [ `Msg of string ] ] Lwt.t
+    t -> (Cstruct.t, [ `Msg of string ]) Lwt_result.t
 end
 
 module type SERVER = sig
@@ -84,7 +85,7 @@ module type SERVER = sig
     address:Dns_forward_config.address ->
     ?local_names_cb:(Dns.Packet.question -> Dns.Packet.rr list option Lwt.t) ->
     ?timeout:float ->
-    t -> [ `Ok of unit | `Error of [ `Msg of string ] ] Lwt.t
+    t -> (unit, [ `Msg of string ]) Lwt_result.t
   val destroy: t -> unit Lwt.t
 end
 
@@ -95,7 +96,7 @@ module type READERWRITER = sig
   type t
   type flow
   val connect: flow -> t
-  val read: t -> [ `Ok of request | `Error of [ `Msg of string ] ] Lwt.t
-  val write: t -> response -> [ `Ok of unit | `Error of [ `Msg of string ] ] Lwt.t
+  val read: t -> (request, [ `Msg of string ]) Lwt_result.t
+  val write: t -> response -> (unit, [ `Msg of string]) Lwt_result.t
   val close: t -> unit Lwt.t
 end

--- a/lib/dns_forward_server.ml
+++ b/lib/dns_forward_server.ml
@@ -15,6 +15,8 @@
  *
  *)
 
+module Lwt_result = Dns_forward_lwt_result (* remove when this is available *)
+
 let src =
   let src = Logs.Src.create "Dns_forward" ~doc:"DNS serving" in
   Logs.Src.set_level src (Some Logs.Debug);
@@ -40,13 +42,13 @@ module Make(Server: Dns_forward_s.RPC_SERVER)(Client: Dns_forward_s.RPC_CLIENT)(
     Lwt.return { resolver; server = None }
 
   let serve ~address ?local_names_cb ?timeout t =
-    let open Dns_forward_error.Lwt.Infix in
+    let open Lwt_result.Infix in
     Server.bind address
     >>= fun server ->
     t.server <- Some server;
     Server.listen server (fun buf -> Resolver.answer ?local_names_cb ?timeout buf t.resolver)
     >>= fun () ->
-    Lwt.return (`Ok ())
+    Lwt_result.return ()
 
   let destroy { resolver; server } =
     Resolver.destroy resolver

--- a/lib_test/server.mli
+++ b/lib_test/server.mli
@@ -23,7 +23,7 @@ module Make(Server: Rpc.Server.S): sig
   val make: (string * Ipaddr.t) list -> t
   (** Construct a server with a fixed set of name mappings *)
 
-  val serve: address: Config.address -> t -> unit Error.t Lwt.t
+  val serve: address: Config.address -> t -> unit Error.t
   (** Serve requests on the given IP and port forever *)
 
   val get_nr_queries: t -> int


### PR DESCRIPTION
- use the same type as `Lwt_result.t` throughout
- add a temporary compatibility shim which can be removed when new `Lwt` is released.