### PR TITLE
Minor API improvements

### DIFF
--- a/bin/impl.ml
+++ b/bin/impl.ml
@@ -61,9 +61,13 @@ let serve port filename =
     >>= fun lines ->
     let all = String.concat "" lines in
     let config = Config.t_of_sexp @@ Sexplib.Sexp.of_string all in
-    Server.Udp.create config
+    Resolver.Udp.create config
+    >>= fun udp_resolver ->
+    Server.Udp.create udp_resolver
     >>= fun udp ->
-    Server.Tcp.create config
+    Resolver.Tcp.create config
+    >>= fun tcp_resolver ->
+    Server.Tcp.create tcp_resolver
     >>= fun tcp ->
     let address = { Config.ip = Ipaddr.V4 Ipaddr.V4.localhost; port } in
     let t =

--- a/lib/dns_forward.mli
+++ b/lib/dns_forward.mli
@@ -208,17 +208,16 @@ module Resolver: sig
   module type S = sig
     type t
 
-    val create: Config.t -> t Lwt.t
+    val create:
+      ?local_names_cb:(Dns.Packet.question -> Dns.Packet.rr list option Lwt.t) ->
+      ?timeout:float ->
+      Config.t -> t Lwt.t
     (** Construct a resolver given some configuration *)
 
     val destroy: t -> unit Lwt.t
     (** Destroy and free all resources associated with the resolver *)
 
-    val answer:
-      ?local_names_cb:(Dns.Packet.question -> Dns.Packet.rr list option Lwt.t) ->
-      ?timeout:float ->
-      Cstruct.t ->
-      t -> Cstruct.t Error.t
+    val answer: Cstruct.t -> t -> Cstruct.t Error.t
     (** Process a query by first checking whether the name can be satisfied
         locally via the [local_names_cb] and failing that, sending it to
         upstream servers according to the resolver configuration. By default
@@ -240,13 +239,14 @@ module Server: sig
     type t
     (** A forwarding DNS proxy *)
 
-    val create: Config.t -> t Lwt.t
+    val create:
+      ?local_names_cb:(Dns.Packet.question -> Dns.Packet.rr list option Lwt.t) ->
+      ?timeout:float ->
+      Config.t -> t Lwt.t
     (** Construct a forwarding DNS proxy given some configuration *)
 
     val serve:
       address:Config.address ->
-      ?local_names_cb:(Dns.Packet.question -> Dns.Packet.rr list option Lwt.t) ->
-      ?timeout:float ->
       t -> unit Error.t
     (** Serve requests on the given [address] forever *)
 

--- a/lib/dns_forward.mli
+++ b/lib/dns_forward.mli
@@ -239,11 +239,10 @@ module Server: sig
     type t
     (** A forwarding DNS proxy *)
 
-    val create:
-      ?local_names_cb:(Dns.Packet.question -> Dns.Packet.rr list option Lwt.t) ->
-      ?timeout:float ->
-      Config.t -> t Lwt.t
-    (** Construct a forwarding DNS proxy given some configuration *)
+    type resolver
+
+    val create: resolver -> t Lwt.t
+    (** Construct a server given a resolver configuration *)
 
     val serve:
       address:Config.address ->
@@ -254,6 +253,6 @@ module Server: sig
     (** Shutdown the server and release allocated resources *)
   end
 
-  module Make(Server: Rpc.Server.S)(Client: Rpc.Client.S)(Time: V1_LWT.TIME): S
+  module Make(Server: Rpc.Server.S)(Resolver: Resolver.S): S with type resolver = Resolver.t
 
 end

--- a/lib/dns_forward_lwt_unix.ml
+++ b/lib/dns_forward_lwt_unix.ml
@@ -456,7 +456,7 @@ module Time = struct
   let sleep = Lwt_unix.sleep
 end
 
-module Resolver = struct
+module R = struct
   open Dns_forward
   module Udp_client = Rpc.Client.Make(Udp)(Framing.Udp(Udp))(Time)
   module Udp = Resolver.Make(Udp_client)(Time)
@@ -467,11 +467,11 @@ end
 
 module Server = struct
   open Dns_forward
-  module Udp_client = Rpc.Client.Make(Udp)(Framing.Udp(Udp))(Time)
   module Udp_server = Rpc.Server.Make(Udp)(Framing.Udp(Udp))(Time)
-  module Udp = Server.Make(Udp_server)(Udp_client)(Time)
+  module Udp = Server.Make(Udp_server)(R.Udp)
 
-  module Tcp_client = Rpc.Client.Make(Tcp)(Framing.Tcp(Tcp))(Time)
   module Tcp_server = Rpc.Server.Make(Tcp)(Framing.Tcp(Tcp))(Time)
-  module Tcp = Server.Make(Tcp_server)(Tcp_client)(Time)
+  module Tcp = Server.Make(Tcp_server)(R.Tcp)
 end
+
+module Resolver = R

--- a/lib/dns_forward_lwt_unix.mli
+++ b/lib/dns_forward_lwt_unix.mli
@@ -26,9 +26,9 @@ module Resolver: sig
 end
 
 module Server: sig
-  module Udp: Dns_forward.Server.S
+  module Udp: Dns_forward.Server.S with type resolver = Resolver.Udp.t
   (** A forwarding DNS proxy over UDP *)
 
-  module Tcp: Dns_forward.Server.S
+  module Tcp: Dns_forward.Server.S with type resolver = Resolver.Tcp.t
   (** A forwarding DNS proxy over TCP *)
 end

--- a/lib/dns_forward_s.ml
+++ b/lib/dns_forward_s.ml
@@ -69,22 +69,23 @@ end
 
 module type RESOLVER = sig
   type t
-  val create: Dns_forward_config.t -> t Lwt.t
-  val destroy: t -> unit Lwt.t
-  val answer:
+  val create:
     ?local_names_cb:(Dns.Packet.question -> Dns.Packet.rr list option Lwt.t) ->
     ?timeout:float ->
-    Cstruct.t ->
-    t -> (Cstruct.t, [ `Msg of string ]) Lwt_result.t
+    Dns_forward_config.t ->
+    t Lwt.t
+  val destroy: t -> unit Lwt.t
+  val answer: Cstruct.t -> t -> (Cstruct.t, [ `Msg of string ]) Lwt_result.t
 end
 
 module type SERVER = sig
   type t
-  val create: Dns_forward_config.t -> t Lwt.t
-  val serve:
-    address:Dns_forward_config.address ->
+  val create:
     ?local_names_cb:(Dns.Packet.question -> Dns.Packet.rr list option Lwt.t) ->
     ?timeout:float ->
+    Dns_forward_config.t -> t Lwt.t
+  val serve:
+    address:Dns_forward_config.address ->
     t -> (unit, [ `Msg of string ]) Lwt_result.t
   val destroy: t -> unit Lwt.t
 end

--- a/lib/dns_forward_s.ml
+++ b/lib/dns_forward_s.ml
@@ -80,10 +80,8 @@ end
 
 module type SERVER = sig
   type t
-  val create:
-    ?local_names_cb:(Dns.Packet.question -> Dns.Packet.rr list option Lwt.t) ->
-    ?timeout:float ->
-    Dns_forward_config.t -> t Lwt.t
+  type resolver
+  val create: resolver -> t Lwt.t
   val serve:
     address:Dns_forward_config.address ->
     t -> (unit, [ `Msg of string ]) Lwt_result.t

--- a/lib/dns_forward_server.ml
+++ b/lib/dns_forward_server.ml
@@ -36,17 +36,17 @@ module Make(Server: Dns_forward_s.RPC_SERVER)(Client: Dns_forward_s.RPC_CLIENT)(
     mutable server: Server.server option;
   }
 
-  let create config =
-    Resolver.create config
+  let create ?local_names_cb ?timeout config =
+    Resolver.create ?local_names_cb ?timeout config
     >>= fun resolver ->
     Lwt.return { resolver; server = None }
 
-  let serve ~address ?local_names_cb ?timeout t =
+  let serve ~address t =
     let open Lwt_result.Infix in
     Server.bind address
     >>= fun server ->
     t.server <- Some server;
-    Server.listen server (fun buf -> Resolver.answer ?local_names_cb ?timeout buf t.resolver)
+    Server.listen server (fun buf -> Resolver.answer buf t.resolver)
     >>= fun () ->
     Lwt_result.return ()
 

--- a/lib/dns_forward_server.ml
+++ b/lib/dns_forward_server.ml
@@ -28,17 +28,16 @@ open Lwt.Infix
 
 module type S = Dns_forward_s.SERVER
 
-module Make(Server: Dns_forward_s.RPC_SERVER)(Client: Dns_forward_s.RPC_CLIENT)(Time: V1_LWT.TIME) = struct
-  module Resolver = Dns_forward_resolver.Make(Client)(Time)
+module Make(Server: Dns_forward_s.RPC_SERVER)(Resolver: Dns_forward_s.RESOLVER) = struct
+
+  type resolver = Resolver.t
 
   type t = {
     resolver: Resolver.t;
     mutable server: Server.server option;
   }
 
-  let create ?local_names_cb ?timeout config =
-    Resolver.create ?local_names_cb ?timeout config
-    >>= fun resolver ->
+  let create resolver =
     Lwt.return { resolver; server = None }
 
   let serve ~address t =

--- a/lib/dns_forward_server.mli
+++ b/lib/dns_forward_server.mli
@@ -17,4 +17,4 @@
 
 module type S = Dns_forward_s.SERVER
 
-module Make(Server: Dns_forward_s.RPC_SERVER)(Client: Dns_forward_s.RPC_CLIENT)(Time: V1_LWT.TIME): S
+module Make(Server: Dns_forward_s.RPC_SERVER)(Resolver: Dns_forward_s.RESOLVER): S with type resolver = Resolver.t

--- a/lib_test/test.ml
+++ b/lib_test/test.ml
@@ -131,9 +131,6 @@ let test_local_lookups () =
       { Dns_forward.Config.address = public_address; zones = [] };
     ] in
     let open Lwt.Infix in
-    F.create config
-    >>= fun f ->
-    let f_address = { Dns_forward.Config.ip = Ipaddr.V4 Ipaddr.V4.localhost; port = 5 } in
     let local_names_cb question =
       let open Dns.Packet in
       match question with
@@ -143,8 +140,11 @@ let test_local_lookups () =
         Lwt.return (Some [ { name; cls; flush; ttl; rdata } ])
       | _ ->
         Lwt.return None in
+    F.create ~local_names_cb config
+    >>= fun f ->
+    let f_address = { Dns_forward.Config.ip = Ipaddr.V4 Ipaddr.V4.localhost; port = 5 } in
     let open Error in
-    F.serve ~address:f_address ~local_names_cb f
+    F.serve ~address:f_address f
     >>= fun () ->
     Rpc.connect f_address
     >>= fun c ->

--- a/lib_test/test.ml
+++ b/lib_test/test.ml
@@ -78,14 +78,17 @@ let test_forwarder_zone () =
 
     S.serve ~address:bar_address bar_server
     >>= fun () ->
-    (* a forwarder which uses both servers *)
-    let module F = Dns_forward.Server.Make(Rpc)(Rpc)(Time) in
+    (* a resolver which uses both servers *)
+    let module R = Dns_forward.Resolver.Make(Rpc)(Time) in
     let config = [
       { Dns_forward.Config.address = foo_address; zones = [ [ "foo" ] ] };
       { Dns_forward.Config.address = bar_address; zones = [] }
     ] in
     let open Lwt.Infix in
-    F.create config
+    R.create config
+    >>= fun r ->
+    let module F = Dns_forward.Server.Make(Rpc)(R) in
+    F.create r
     >>= fun f ->
     let f_address = { Dns_forward.Config.ip = Ipaddr.V4 Ipaddr.V4.localhost; port = 3 } in
     let open Error in
@@ -126,7 +129,8 @@ let test_local_lookups () =
     let open Error in
     S.serve ~address:public_address public_server
     >>= fun () ->
-    let module F = Dns_forward.Server.Make(Rpc)(Rpc)(Time) in
+    let module R = Dns_forward.Resolver.Make(Rpc)(Time) in
+
     let config = [
       { Dns_forward.Config.address = public_address; zones = [] };
     ] in
@@ -140,7 +144,10 @@ let test_local_lookups () =
         Lwt.return (Some [ { name; cls; flush; ttl; rdata } ])
       | _ ->
         Lwt.return None in
-    F.create ~local_names_cb config
+    R.create ~local_names_cb config
+    >>= fun r ->
+    let module F = Dns_forward.Server.Make(Rpc)(R) in
+    F.create r
     >>= fun f ->
     let f_address = { Dns_forward.Config.ip = Ipaddr.V4 Ipaddr.V4.localhost; port = 5 } in
     let open Error in
@@ -178,12 +185,15 @@ let test_tcp_multiplexing () =
     let open Error in
     S.serve ~address:public_address public_server
     >>= fun () ->
-    let module F = Dns_forward.Server.Make(Proto_server)(Proto_client)(Time) in
+    let module R = Dns_forward.Resolver.Make(Proto_client)(Time) in
     let config = [
       { Dns_forward.Config.address = public_address; zones = [] };
     ] in
     let open Lwt.Infix in
-    F.create config
+    R.create config
+    >>= fun r ->
+    let module F = Dns_forward.Server.Make(Proto_server)(R) in
+    F.create r
     >>= fun f ->
     let f_address = { Dns_forward.Config.ip = Ipaddr.V4 Ipaddr.V4.localhost; port = 7 } in
     let open Error in

--- a/pkg/META
+++ b/pkg/META
@@ -10,7 +10,7 @@ exists_if = "dns-forward.cma"
 package "lwt-unix" (
  description = "Lwt_unix I/O library"
  version = "%%VERSION%%"
- requires = "lwt.unix lwt logs rresult cstruct cstruct.lwt ipaddr"
+ requires = "io-page.unix dns-forward lwt.unix lwt logs rresult cstruct cstruct.lwt ipaddr"
  archive(byte) = "dns-forward-lwt-unix.cma"
  archive(native) = "dns-forward-lwt-unix.cmxa"
  plugin(byte) = "dns-forward-lwt-unix.cma"

--- a/pkg/pkg.ml
+++ b/pkg/pkg.ml
@@ -20,7 +20,7 @@ let () =
   | "dns-forward" -> Ok [
       Pkg.lib   "pkg/META";
       Pkg.lib   "opam";
-      Pkg.mllib ~api:["Dns_forward"] "lib/dns-forward.mllib";
+      Pkg.mllib ~api:["Dns_forward"; "Dns_forward_lwt_unix"] "lib/dns-forward.mllib";
       Pkg.mllib "lib/dns-forward-lwt-unix.mllib";
       Pkg.bin   "bin/main" ~dst:"dns-forwarder";
       Pkg.test  "lib_test/test" ~args:(Cmd.v "-q");


### PR DESCRIPTION
- move the remaining configuration/policy to `Resolver.create` (`local_names_cb` and `timeout`)
- `Server` now takes a `Resolver` as an argument