### PR TITLE
Improve the Config API

### DIFF
--- a/bin/impl.ml
+++ b/bin/impl.ml
@@ -69,7 +69,7 @@ let serve port filename =
     >>= fun tcp_resolver ->
     Server.Tcp.create tcp_resolver
     >>= fun tcp ->
-    let address = { Config.ip = Ipaddr.V4 Ipaddr.V4.localhost; port } in
+    let address = { Config.Address.ip = Ipaddr.V4 Ipaddr.V4.localhost; port } in
     let t =
       let open Error.Infix in
       Server.Udp.serve ~address udp

--- a/lib/dns_forward.mli
+++ b/lib/dns_forward.mli
@@ -117,6 +117,8 @@ module Config: sig
     (** The address of a DNS server *)
 
     include Comparable with type t := t
+    module Set: Set.S with type elt = t
+    module Map: Map.S with type key = t
   end
 
   module Domain: sig

--- a/lib/dns_forward.mli
+++ b/lib/dns_forward.mli
@@ -143,6 +143,8 @@ module Config: sig
         leaking internal names by sending queries to public server. *)
 
     include Comparable with type t := t
+    module Set: Set.S with type elt = t
+    module Map: Map.S with type key = t
   end
 
   type t = Server.t list [@@deriving sexp]

--- a/lib/dns_forward.mli
+++ b/lib/dns_forward.mli
@@ -150,6 +150,7 @@ module Config: sig
   type t = Server.Set.t [@@deriving sexp]
   (** Upstream DNS servers *)
 
+  include Comparable with type t := t
 end
 
 module Rpc: sig

--- a/lib/dns_forward.mli
+++ b/lib/dns_forward.mli
@@ -147,7 +147,7 @@ module Config: sig
     module Map: Map.S with type key = t
   end
 
-  type t = Server.t list [@@deriving sexp]
+  type t = Server.Set.t [@@deriving sexp]
   (** Upstream DNS servers *)
 
 end

--- a/lib/dns_forward.mli
+++ b/lib/dns_forward.mli
@@ -119,11 +119,15 @@ module Config: sig
     include Comparable with type t := t
   end
 
-  type domain = string list
-  (** A DNS domain e.g. [ "a"; "b" ] would be the domain a.b. *)
+  module Domain: sig
+    type t = string list
+    (** A DNS domain e.g. [ "a"; "b" ] would be the domain a.b. *)
+
+    include Comparable with type t := t
+  end
 
   type server = {
-    zones: domain list; (** use this server for these specific domains *)
+    zones: Domain.t list; (** use this server for these specific domains *)
     address: Address.t;
   }
   (** A single upstream DNS server. If [zones = []] then the server can handle

--- a/lib/dns_forward.mli
+++ b/lib/dns_forward.mli
@@ -25,6 +25,12 @@ module Error: sig
   end
 end
 
+module type Comparable = sig
+  type t
+
+  val compare: t -> t -> int
+end
+
 module Flow: sig
   (** A BSD-socket-like interface for establishing flows by connecting to a
       well-known address (see Client) or by listening for incoming connections
@@ -109,6 +115,8 @@ module Config: sig
       port: int;
     }
     (** The address of a DNS server *)
+
+    include Comparable with type t := t
   end
 
   type domain = string list

--- a/lib/dns_forward.mli
+++ b/lib/dns_forward.mli
@@ -103,18 +103,20 @@ module Framing: sig
 end
 
 module Config: sig
-  type address = {
-    ip: Ipaddr.t;
-    port: int;
-  }
-  (** The address of a DNS server *)
+  module Address: sig
+    type t = {
+      ip: Ipaddr.t;
+      port: int;
+    }
+    (** The address of a DNS server *)
+  end
 
   type domain = string list
   (** A DNS domain e.g. [ "a"; "b" ] would be the domain a.b. *)
 
   type server = {
     zones: domain list; (** use this server for these specific domains *)
-    address: address;
+    address: Address.t;
   }
   (** A single upstream DNS server. If [zones = []] then the server can handle
       all queries; otherwise [zones] is a list of domains that this server
@@ -143,7 +145,7 @@ module Rpc: sig
       type response = Cstruct.t
       (** A complete response *)
 
-      type address = Config.address
+      type address = Config.Address.t
       (** The address of the remote endpoint *)
 
       val connect: address -> t Error.t
@@ -178,7 +180,7 @@ module Rpc: sig
       type response = Cstruct.t
       (** A complete response *)
 
-      type address = Config.address
+      type address = Config.Address.t
       (** The address of the server *)
 
       val bind: address -> server Error.t
@@ -245,7 +247,7 @@ module Server: sig
     (** Construct a server given a resolver configuration *)
 
     val serve:
-      address:Config.address ->
+      address:Config.Address.t ->
       t -> unit Error.t
     (** Serve requests on the given [address] forever *)
 

--- a/lib/dns_forward.mli
+++ b/lib/dns_forward.mli
@@ -124,20 +124,26 @@ module Config: sig
     (** A DNS domain e.g. [ "a"; "b" ] would be the domain a.b. *)
 
     include Comparable with type t := t
+    module Set: Set.S with type elt = t
+    module Map: Map.S with type key = t
   end
 
-  type server = {
-    zones: Domain.t list; (** use this server for these specific domains *)
-    address: Address.t;
-  }
-  (** A single upstream DNS server. If [zones = []] then the server can handle
-      all queries; otherwise [zones] is a list of domains that this server
-      should be preferentially queried for. For example if an organisation
-      has a VPN and a special DNS server for the domain `mirage.io` it may
-      want to only send queries for `foo.mirage.io` to this server and avoid
-      leaking internal names by sending queries to public server. *)
+  module Server: sig
+    type t = {
+      zones: Domain.Set.t; (** use this server for these specific domains *)
+      address: Address.t;
+    }
+    (** A single upstream DNS server. If [zones = []] then the server can handle
+        all queries; otherwise [zones] is a list of domains that this server
+        should be preferentially queried for. For example if an organisation
+        has a VPN and a special DNS server for the domain `mirage.io` it may
+        want to only send queries for `foo.mirage.io` to this server and avoid
+        leaking internal names by sending queries to public server. *)
 
-  type t = server list [@@deriving sexp]
+    include Comparable with type t := t
+  end
+
+  type t = Server.t list [@@deriving sexp]
   (** Upstream DNS servers *)
 
 end

--- a/lib/dns_forward_config.ml
+++ b/lib/dns_forward_config.ml
@@ -17,14 +17,19 @@
 open Sexplib.Std
 
 module Address = struct
-  type t = {
-    ip: Ipaddr.t;
-    port: int;
-  } [@@deriving sexp]
+  module M = struct
+    type t = {
+      ip: Ipaddr.t;
+      port: int;
+    } [@@deriving sexp]
 
-  let compare a b =
-    let ip = Ipaddr.compare a.ip b.ip in
-    if ip <> 0 then ip else Pervasives.compare a.port b.port
+    let compare a b =
+      let ip = Ipaddr.compare a.ip b.ip in
+      if ip <> 0 then ip else Pervasives.compare a.port b.port
+  end
+  include M
+  module Set = Set.Make(M)
+  module Map = Map.Make(M)
 end
 
 module Domain = struct

--- a/lib/dns_forward_config.ml
+++ b/lib/dns_forward_config.ml
@@ -21,6 +21,10 @@ module Address = struct
     ip: Ipaddr.t;
     port: int;
   } [@@deriving sexp]
+
+  let compare a b =
+    let ip = Ipaddr.compare a.ip b.ip in
+    if ip <> 0 then ip else Pervasives.compare a.port b.port
 end
 
 type domain = string list [@@deriving sexp]

--- a/lib/dns_forward_config.ml
+++ b/lib/dns_forward_config.ml
@@ -27,10 +27,14 @@ module Address = struct
     if ip <> 0 then ip else Pervasives.compare a.port b.port
 end
 
-type domain = string list [@@deriving sexp]
+module Domain = struct
+  type t = string list [@@deriving sexp]
+
+  let compare (a: t) (b: t) = Pervasives.compare a b
+end
 
 type server = {
-  zones: domain list;
+  zones: Domain.t list;
   address: Address.t;
 } [@@deriving sexp]
 

--- a/lib/dns_forward_config.ml
+++ b/lib/dns_forward_config.ml
@@ -77,3 +77,4 @@ module Server = struct
 end
 
 type t = Server.Set.t [@@deriving sexp]
+let compare = Server.Set.compare

--- a/lib/dns_forward_config.ml
+++ b/lib/dns_forward_config.ml
@@ -16,16 +16,18 @@
  *)
 open Sexplib.Std
 
-type address = {
-  ip: Ipaddr.t;
-  port: int;
-} [@@deriving sexp]
+module Address = struct
+  type t = {
+    ip: Ipaddr.t;
+    port: int;
+  } [@@deriving sexp]
+end
 
 type domain = string list [@@deriving sexp]
 
 type server = {
   zones: domain list;
-  address: address;
+  address: Address.t;
 } [@@deriving sexp]
 
 type t = server list [@@deriving sexp]

--- a/lib/dns_forward_config.ml
+++ b/lib/dns_forward_config.ml
@@ -63,8 +63,17 @@ module Server = struct
       if address <> 0 then address else Domain.Set.compare a.zones a.zones
   end
   include M
-  module Set = Set.Make(M)
+  module Set = struct
+    include Set.Make(M)
+    type _t = M.t list [@@deriving sexp]
+    let t_of_sexp (sexp: Sexplib.Type.t) : t =
+      let _t = _t_of_sexp sexp in
+      List.fold_left (fun set elt -> add elt set) empty _t
+    let sexp_of_t (t: t) : Sexplib.Type.t =
+      let _t = fold (fun elt acc -> elt :: acc) t [] in
+      sexp_of__t _t
+  end
   module Map = Map.Make(M)
 end
 
-type t = Server.t list [@@deriving sexp]
+type t = Server.Set.t [@@deriving sexp]

--- a/lib/dns_forward_config.ml
+++ b/lib/dns_forward_config.ml
@@ -52,14 +52,19 @@ module Domain = struct
 end
 
 module Server = struct
-  type t = {
-    zones: Domain.Set.t;
-    address: Address.t;
-  } [@@deriving sexp]
+  module M = struct
+    type t = {
+      zones: Domain.Set.t;
+      address: Address.t;
+    } [@@deriving sexp]
 
-  let compare (a: t) (b: t) =
-    let address = Address.compare a.address b.address in
-    if address <> 0 then address else Domain.Set.compare a.zones a.zones
+    let compare (a: t) (b: t) =
+      let address = Address.compare a.address b.address in
+      if address <> 0 then address else Domain.Set.compare a.zones a.zones
+  end
+  include M
+  module Set = Set.Make(M)
+  module Map = Map.Make(M)
 end
 
 type t = Server.t list [@@deriving sexp]

--- a/lib/dns_forward_config.mli
+++ b/lib/dns_forward_config.mli
@@ -24,10 +24,14 @@ module Address: sig
   val compare: t -> t -> int
 end
 
-type domain = string list
+module Domain: sig
+  type t = string list
+
+  val compare: t -> t -> int
+end
 
 type server = {
-  zones: domain list; (** use this server for these specific domains *)
+  zones: Domain.t list; (** use this server for these specific domains *)
   address: Address.t;
 }
 (** A single upstream DNS server *)

--- a/lib/dns_forward_config.mli
+++ b/lib/dns_forward_config.mli
@@ -22,6 +22,8 @@ module Address: sig
   }
 
   val compare: t -> t -> int
+  module Set: Set.S with type elt = t
+  module Map: Map.S with type key = t
 end
 
 module Domain: sig

--- a/lib/dns_forward_config.mli
+++ b/lib/dns_forward_config.mli
@@ -49,3 +49,5 @@ end
 
 type t = Server.Set.t [@@deriving sexp]
 (** Upstream DNS servers *)
+
+val compare: t -> t -> int

--- a/lib/dns_forward_config.mli
+++ b/lib/dns_forward_config.mli
@@ -15,16 +15,18 @@
  *
  *)
 
-type address = {
-  ip: Ipaddr.t;
-  port: int;
-}
+module Address: sig
+  type t = {
+    ip: Ipaddr.t;
+    port: int;
+  }
+end
 
 type domain = string list
 
 type server = {
   zones: domain list; (** use this server for these specific domains *)
-  address: address;
+  address: Address.t;
 }
 (** A single upstream DNS server *)
 

--- a/lib/dns_forward_config.mli
+++ b/lib/dns_forward_config.mli
@@ -28,13 +28,20 @@ module Domain: sig
   type t = string list
 
   val compare: t -> t -> int
+
+  module Set: Set.S with type elt = t
+  module Map: Map.S with type key = t
 end
 
-type server = {
-  zones: Domain.t list; (** use this server for these specific domains *)
-  address: Address.t;
-}
-(** A single upstream DNS server *)
+module Server: sig
+  type t = {
+    zones: Domain.Set.t; (** use this server for these specific domains *)
+    address: Address.t;
+  }
+  (** A single upstream DNS server *)
 
-type t = server list [@@deriving sexp]
+  val compare: t -> t -> int
+end
+
+type t = Server.t list [@@deriving sexp]
 (** Upstream DNS servers *)

--- a/lib/dns_forward_config.mli
+++ b/lib/dns_forward_config.mli
@@ -43,6 +43,8 @@ module Server: sig
   (** A single upstream DNS server *)
 
   val compare: t -> t -> int
+  module Set: Set.S with type elt = t
+  module Map: Map.S with type key = t
 end
 
 type t = Server.t list [@@deriving sexp]

--- a/lib/dns_forward_config.mli
+++ b/lib/dns_forward_config.mli
@@ -20,6 +20,8 @@ module Address: sig
     ip: Ipaddr.t;
     port: int;
   }
+
+  val compare: t -> t -> int
 end
 
 type domain = string list

--- a/lib/dns_forward_config.mli
+++ b/lib/dns_forward_config.mli
@@ -47,5 +47,5 @@ module Server: sig
   module Map: Map.S with type key = t
 end
 
-type t = Server.t list [@@deriving sexp]
+type t = Server.Set.t [@@deriving sexp]
 (** Upstream DNS servers *)

--- a/lib/dns_forward_resolver.ml
+++ b/lib/dns_forward_resolver.ml
@@ -79,7 +79,7 @@ module Make(Client: Dns_forward_s.RPC_CLIENT)(Time: V1_LWT.TIME) = struct
       or_fail_msg @@ Client.connect server.Dns_forward_config.Server.address
       >>= fun client ->
       Lwt.return (server, client)
-    ) config
+    ) (Dns_forward_config.Server.Set.elements config)
     >>= fun connections ->
     Lwt.return { connections; local_names_cb; timeout }
 

--- a/lib/dns_forward_resolver.ml
+++ b/lib/dns_forward_resolver.ml
@@ -115,7 +115,7 @@ module Make(Client: Dns_forward_s.RPC_CLIENT)(Time: V1_LWT.TIME) = struct
         let rpc server =
           let open Dns_forward_config in
           let _, client = List.find (fun (s, _) -> s = server) t.connections in
-          Log.debug (fun f -> f "forwarding to server %s:%d" (Ipaddr.to_string server.address.ip) server.address.port);
+          Log.debug (fun f -> f "forwarding to server %s:%d" (Ipaddr.to_string server.address.Address.ip) server.address.Address.port);
           or_fail_msg @@ Client.rpc client buffer
           >>= fun reply ->
           Lwt.return (Some reply) in

--- a/lib/dns_forward_rpc.ml
+++ b/lib/dns_forward_rpc.ml
@@ -31,7 +31,7 @@ module Client = struct
     (Sockets: Dns_forward_s.FLOW_CLIENT with type address = Ipaddr.t * int)
     (Packet: Dns_forward_s.READERWRITER with type flow = Sockets.flow)
     (Time: V1_LWT.TIME) = struct
-    type address = Dns_forward_config.address
+    type address = Dns_forward_config.Address.t
     type request = Cstruct.t
     type response = Cstruct.t
 
@@ -105,7 +105,7 @@ module Client = struct
       Lwt_mutex.with_lock t.m
         (fun () -> match t.rw with
           | None ->
-            Sockets.connect (t.address.Dns_forward_config.ip, t.address.Dns_forward_config.port)
+            Sockets.connect (t.address.Dns_forward_config.Address.ip, t.address.Dns_forward_config.Address.port)
             >>= fun flow ->
             let rw = Packet.connect flow in
             t.rw <- Some rw;
@@ -195,7 +195,7 @@ module Server = struct
     (Sockets: Dns_forward_s.FLOW_SERVER with type address = Ipaddr.t * int)
     (Packet: Dns_forward_s.READERWRITER with type flow = Sockets.flow)
     (Time: V1_LWT.TIME) = struct
-    type address = Dns_forward_config.address
+    type address = Dns_forward_config.Address.t
     type request = Cstruct.t
     type response = Cstruct.t
 
@@ -206,7 +206,7 @@ module Server = struct
 
     let bind address =
       let open Lwt_result.Infix in
-      Sockets.bind (address.Dns_forward_config.ip, address.Dns_forward_config.port)
+      Sockets.bind (address.Dns_forward_config.Address.ip, address.Dns_forward_config.Address.port)
       >>= fun server ->
       Lwt_result.return { address; server }
 

--- a/lib/dns_forward_s.ml
+++ b/lib/dns_forward_s.ml
@@ -49,7 +49,7 @@ end
 module type RPC_CLIENT = sig
   type request = Cstruct.t
   type response = Cstruct.t
-  type address = Dns_forward_config.address
+  type address = Dns_forward_config.Address.t
   type t
   val connect: address -> (t, [ `Msg of string ]) Lwt_result.t
   val rpc: t -> request -> (response, [ `Msg of string ]) Lwt_result.t
@@ -59,7 +59,7 @@ end
 module type RPC_SERVER = sig
   type request = Cstruct.t
   type response = Cstruct.t
-  type address = Dns_forward_config.address
+  type address = Dns_forward_config.Address.t
 
   type server
   val bind: address -> (server, [ `Msg of string ]) Lwt_result.t
@@ -83,7 +83,7 @@ module type SERVER = sig
   type resolver
   val create: resolver -> t Lwt.t
   val serve:
-    address:Dns_forward_config.address ->
+    address:Dns_forward_config.Address.t ->
     t -> (unit, [ `Msg of string ]) Lwt_result.t
   val destroy: t -> unit Lwt.t
 end

--- a/lib/dns_forward_s.ml
+++ b/lib/dns_forward_s.ml
@@ -16,6 +16,12 @@
  *)
 module Lwt_result = Dns_forward_lwt_result (* remove when this is available *)
 
+module type Comparable = sig
+  type t
+
+  val compare: t -> t -> int
+end
+
 module type FLOW_CLIENT = sig
   include Mirage_flow_s.SHUTDOWNABLE
   type address

--- a/lib_test/rpc.ml
+++ b/lib_test/rpc.ml
@@ -19,8 +19,8 @@ let errorf = Dns_forward_error.errorf
 
 type request = Cstruct.t
 type response = Cstruct.t
-type address = Config.address
-let string_of_address a = Ipaddr.to_string a.Config.ip ^ ":" ^ (string_of_int a.Config.port)
+type address = Config.Address.t
+let string_of_address a = Ipaddr.to_string a.Config.Address.ip ^ ":" ^ (string_of_int a.Config.Address.port)
 
 type cb = request -> (response, [ `Msg of string ]) Result.result Lwt.t
 

--- a/lib_test/rpc.mli
+++ b/lib_test/rpc.mli
@@ -19,7 +19,7 @@
 
 type request = Cstruct.t
 type response = Cstruct.t
-type address = Dns_forward.Config.address
+type address = Dns_forward.Config.Address.t
 
 include Dns_forward.Rpc.Client.S
   with type request  := request

--- a/lib_test/server.mli
+++ b/lib_test/server.mli
@@ -23,7 +23,7 @@ module Make(Server: Rpc.Server.S): sig
   val make: (string * Ipaddr.t) list -> t
   (** Construct a server with a fixed set of name mappings *)
 
-  val serve: address: Config.address -> t -> unit Error.t
+  val serve: address: Config.Address.t -> t -> unit Error.t
   (** Serve requests on the given IP and port forever *)
 
   val get_nr_queries: t -> int

--- a/lib_test/test.ml
+++ b/lib_test/test.ml
@@ -34,7 +34,7 @@ let test_server () =
     let s = S.make [ "foo", Ipaddr.V4 Ipaddr.V4.localhost; "bar", Ipaddr.of_string_exn "1.2.3.4" ] in
     let open Error in
     (* The virtual address we run our server on: *)
-    let address = { Dns_forward.Config.ip = Ipaddr.V4 Ipaddr.V4.localhost; port = 53 } in
+    let address = { Dns_forward.Config.Address.ip = Ipaddr.V4 Ipaddr.V4.localhost; port = 53 } in
     S.serve ~address s
     >>= fun () ->
     Rpc.connect address
@@ -66,10 +66,10 @@ let test_forwarder_zone () =
   let foo_private = "192.168.1.1" in
   (* a VPN mapping 'foo' to an internal ip *)
   let foo_server = S.make [ "foo", Ipaddr.of_string_exn foo_private ] in
-  let foo_address = { Dns_forward.Config.ip = Ipaddr.V4 Ipaddr.V4.localhost; port = 1 } in
+  let foo_address = { Dns_forward.Config.Address.ip = Ipaddr.V4 Ipaddr.V4.localhost; port = 1 } in
   (* a public server mapping 'foo' to a public ip *)
   let bar_server = S.make [ "foo", Ipaddr.of_string_exn foo_public ] in
-  let bar_address = { Dns_forward.Config.ip = Ipaddr.V4 Ipaddr.V4.localhost; port = 2 } in
+  let bar_address = { Dns_forward.Config.Address.ip = Ipaddr.V4 Ipaddr.V4.localhost; port = 2 } in
 
   let open Error in
   match Lwt_main.run begin
@@ -90,7 +90,7 @@ let test_forwarder_zone () =
     let module F = Dns_forward.Server.Make(Rpc)(R) in
     F.create r
     >>= fun f ->
-    let f_address = { Dns_forward.Config.ip = Ipaddr.V4 Ipaddr.V4.localhost; port = 3 } in
+    let f_address = { Dns_forward.Config.Address.ip = Ipaddr.V4 Ipaddr.V4.localhost; port = 3 } in
     let open Error in
     F.serve ~address:f_address f
     >>= fun () ->
@@ -125,7 +125,7 @@ let test_local_lookups () =
     let foo_private = "192.168.1.1" in
     (* a public server mapping 'foo' to a public ip *)
     let public_server = S.make [ "foo", Ipaddr.of_string_exn foo_public ] in
-    let public_address = { Dns_forward.Config.ip = Ipaddr.V4 Ipaddr.V4.localhost; port = 4 } in
+    let public_address = { Dns_forward.Config.Address.ip = Ipaddr.V4 Ipaddr.V4.localhost; port = 4 } in
     let open Error in
     S.serve ~address:public_address public_server
     >>= fun () ->
@@ -149,7 +149,7 @@ let test_local_lookups () =
     let module F = Dns_forward.Server.Make(Rpc)(R) in
     F.create r
     >>= fun f ->
-    let f_address = { Dns_forward.Config.ip = Ipaddr.V4 Ipaddr.V4.localhost; port = 5 } in
+    let f_address = { Dns_forward.Config.Address.ip = Ipaddr.V4 Ipaddr.V4.localhost; port = 5 } in
     let open Error in
     F.serve ~address:f_address f
     >>= fun () ->
@@ -181,7 +181,7 @@ let test_tcp_multiplexing () =
     let foo_public = "8.8.8.8" in
     (* a public server mapping 'foo' to a public ip *)
     let public_server = S.make [ "foo", Ipaddr.of_string_exn foo_public ] in
-    let public_address = { Dns_forward.Config.ip = Ipaddr.V4 Ipaddr.V4.localhost; port = 6 } in
+    let public_address = { Dns_forward.Config.Address.ip = Ipaddr.V4 Ipaddr.V4.localhost; port = 6 } in
     let open Error in
     S.serve ~address:public_address public_server
     >>= fun () ->
@@ -195,7 +195,7 @@ let test_tcp_multiplexing () =
     let module F = Dns_forward.Server.Make(Proto_server)(R) in
     F.create r
     >>= fun f ->
-    let f_address = { Dns_forward.Config.ip = Ipaddr.V4 Ipaddr.V4.localhost; port = 7 } in
+    let f_address = { Dns_forward.Config.Address.ip = Ipaddr.V4 Ipaddr.V4.localhost; port = 7 } in
     let open Error in
     F.serve ~address:f_address f
     >>= fun () ->

--- a/lib_test/test.ml
+++ b/lib_test/test.ml
@@ -80,9 +80,10 @@ let test_forwarder_zone () =
     >>= fun () ->
     (* a resolver which uses both servers *)
     let module R = Dns_forward.Resolver.Make(Rpc)(Time) in
+    let open Dns_forward.Config in
     let config = [
-      { Dns_forward.Config.address = foo_address; zones = [ [ "foo" ] ] };
-      { Dns_forward.Config.address = bar_address; zones = [] }
+      { Server.address = foo_address; zones = Domain.Set.add [ "foo" ] Domain.Set.empty };
+      { Server.address = bar_address; zones = Domain.Set.empty }
     ] in
     let open Lwt.Infix in
     R.create config
@@ -130,9 +131,9 @@ let test_local_lookups () =
     S.serve ~address:public_address public_server
     >>= fun () ->
     let module R = Dns_forward.Resolver.Make(Rpc)(Time) in
-
+    let open Dns_forward.Config in
     let config = [
-      { Dns_forward.Config.address = public_address; zones = [] };
+      { Server.address = public_address; zones = Domain.Set.empty };
     ] in
     let open Lwt.Infix in
     let local_names_cb question =
@@ -186,8 +187,9 @@ let test_tcp_multiplexing () =
     S.serve ~address:public_address public_server
     >>= fun () ->
     let module R = Dns_forward.Resolver.Make(Proto_client)(Time) in
+    let open Dns_forward.Config in
     let config = [
-      { Dns_forward.Config.address = public_address; zones = [] };
+      { Server.address = public_address; zones = Domain.Set.empty };
     ] in
     let open Lwt.Infix in
     R.create config

--- a/lib_test/test.ml
+++ b/lib_test/test.ml
@@ -81,7 +81,7 @@ let test_forwarder_zone () =
     (* a resolver which uses both servers *)
     let module R = Dns_forward.Resolver.Make(Rpc)(Time) in
     let open Dns_forward.Config in
-    let config = [
+    let config = Server.Set.of_list [
       { Server.address = foo_address; zones = Domain.Set.add [ "foo" ] Domain.Set.empty };
       { Server.address = bar_address; zones = Domain.Set.empty }
     ] in
@@ -132,7 +132,7 @@ let test_local_lookups () =
     >>= fun () ->
     let module R = Dns_forward.Resolver.Make(Rpc)(Time) in
     let open Dns_forward.Config in
-    let config = [
+    let config = Server.Set.of_list [
       { Server.address = public_address; zones = Domain.Set.empty };
     ] in
     let open Lwt.Infix in
@@ -188,7 +188,7 @@ let test_tcp_multiplexing () =
     >>= fun () ->
     let module R = Dns_forward.Resolver.Make(Proto_client)(Time) in
     let open Dns_forward.Config in
-    let config = [
+    let config = Server.Set.of_list [
       { Server.address = public_address; zones = Domain.Set.empty };
     ] in
     let open Lwt.Infix in


### PR DESCRIPTION
- each type now has its own module and is called `type t`
- each type now has a `compare` function
- where order is not important, we use `Set.S` instances, so the `compare` function will not be sensitive to unnecessary changes in order