### PR TITLE
Add configuration parsers and printer

### DIFF
--- a/lib/dns_forward.mli
+++ b/lib/dns_forward.mli
@@ -147,7 +147,9 @@ module Config: sig
     module Map: Map.S with type key = t
   end
 
-  type t = Server.Set.t [@@deriving sexp]
+  type t = {
+    servers: Server.Set.t
+  } [@@deriving sexp]
   (** Upstream DNS servers *)
 
   include Comparable with type t := t

--- a/lib/dns_forward.mli
+++ b/lib/dns_forward.mli
@@ -151,6 +151,19 @@ module Config: sig
   (** Upstream DNS servers *)
 
   include Comparable with type t := t
+
+  val to_string: t -> string
+  (** Return a human-readable string corresponding to a configuration *)
+
+  val of_string: string -> (t, [ `Msg of string ]) Result.result
+  (** Parse the output of [to_string] *)
+
+  val compare: t -> t -> int
+
+  module Unix: sig
+    val of_resolv_conf: string -> (t, [ `Msg of string ]) Result.result
+    (** Parse a Unix-style /etc/resolv.conf file *)
+  end
 end
 
 module Rpc: sig

--- a/lib/dns_forward.mli
+++ b/lib/dns_forward.mli
@@ -148,9 +148,10 @@ module Config: sig
   end
 
   type t = {
-    servers: Server.Set.t
+    servers: Server.Set.t; (** Upstream DNS servers *)
+    search: string list;   (** Ordered list of domains to search *)
   } [@@deriving sexp]
-  (** Upstream DNS servers *)
+  (** A DNS configuration *)
 
   include Comparable with type t := t
 

--- a/lib/dns_forward_config.ml
+++ b/lib/dns_forward_config.ml
@@ -76,8 +76,11 @@ module Server = struct
   module Map = Map.Make(M)
 end
 
-type t = Server.Set.t [@@deriving sexp]
-let compare = Server.Set.compare
+type t = {
+  servers: Server.Set.t;
+} [@@deriving sexp]
+
+let compare a b = Server.Set.compare a.servers b.servers
 
 let to_string _ = failwith "unimplemented"
 let of_string _ = failwith "unimplemented"

--- a/lib/dns_forward_config.ml
+++ b/lib/dns_forward_config.ml
@@ -78,9 +78,12 @@ end
 
 type t = {
   servers: Server.Set.t;
+  search: string list;
 } [@@deriving sexp]
 
-let compare a b = Server.Set.compare a.servers b.servers
+let compare a b =
+  let servers = Server.Set.compare a.servers b.servers in
+  if servers <> 0 then servers else Pervasives.compare a.search b.search
 
 let to_string _ = failwith "unimplemented"
 let of_string _ = failwith "unimplemented"

--- a/lib/dns_forward_config.ml
+++ b/lib/dns_forward_config.ml
@@ -78,3 +78,10 @@ end
 
 type t = Server.Set.t [@@deriving sexp]
 let compare = Server.Set.compare
+
+let to_string _ = failwith "unimplemented"
+let of_string _ = failwith "unimplemented"
+
+module Unix = struct
+  let of_resolv_conf _ = failwith "unimplemented"
+end

--- a/lib/dns_forward_config.ml
+++ b/lib/dns_forward_config.ml
@@ -49,6 +49,7 @@ module Domain = struct
       sexp_of__t _t
   end
   module Map = Map.Make(M)
+  let to_string = String.concat "."
 end
 
 module Server = struct
@@ -85,8 +86,72 @@ let compare a b =
   let servers = Server.Set.compare a.servers b.servers in
   if servers <> 0 then servers else Pervasives.compare a.search b.search
 
-let to_string _ = failwith "unimplemented"
-let of_string _ = failwith "unimplemented"
+let nameserver_prefix = "nameserver "
+let search_prefix = "search "
+let zone_prefix = "zone "
+
+let of_string txt =
+  let open Astring in
+  try
+    (* Chop into lines *)
+    String.cuts ~sep:"\n" txt
+    |> List.map (String.trim ?drop:None)
+    |> List.filter (fun x -> x <> "")
+    |> List.fold_left
+      (fun acc line ->
+        if String.is_prefix ~affix:nameserver_prefix line then begin
+          let line = String.with_range ~first:(String.length nameserver_prefix) line in
+          if String.cut ~sep:"::" line <> None then begin
+            (* IPv6 *)
+            let host = Ipaddr.V6.of_string_exn line in
+            (`Nameserver (Ipaddr.V6 host, 53)) :: acc
+          end else match String.cut ~sep:"#" line with
+            | Some (host, port) ->
+              (* IPv4 with non-standard port *)
+              let host = Ipaddr.V4.of_string_exn host in
+              let port = int_of_string port in
+              (`Nameserver (Ipaddr.V4 host, port)) :: acc
+            | None ->
+              (* IPv4 with standard port *)
+              let host = Ipaddr.V4.of_string_exn line in
+              (`Nameserver (Ipaddr.V4 host, 53)) :: acc
+        end else if String.is_prefix ~affix:zone_prefix line then begin
+          let line = String.with_range ~first:(String.length zone_prefix) line in
+          (`Zones (String.cuts ~sep:" " line)) :: acc
+        end else if String.is_prefix ~affix:search_prefix line then begin
+          let line = String.with_range ~first:(String.length search_prefix) line in
+          (`Search (String.cuts ~sep:" " line)) :: acc
+        end else acc
+      ) []
+    (* Merge the zones and nameservers together *)
+    |> List.fold_left
+      (fun (zones_opt, acc) line -> match zones_opt, line with
+        | _, `Zones zones -> (Some zones, acc)
+        | Some zones, `Nameserver (ip, port) ->
+          let zones = List.map (String.cuts ~sep:"." ?rev:None ?empty:None) zones |> Domain.Set.of_list in
+          let server = { Server.address = { Address.ip; port }; zones } in
+          None, { acc with servers = Server.Set.add server acc.servers }
+        | None, `Nameserver (ip, port) ->
+          let server = { Server.address = { Address.ip; port }; zones = Domain.Set.empty } in
+          None, { acc with servers = Server.Set.add server acc.servers }
+        | _, `Search search ->
+          zones_opt, { acc with search }
+      ) (None, { servers = Server.Set.empty; search = [] })
+    |> snd |> fun x -> Result.Ok x
+  with e -> Result.Error (`Msg (Printf.sprintf "Failed to parse configuration: %s" (Printexc.to_string e)))
+
+let to_string t =
+  let nameservers = Server.Set.fold
+    (fun server acc ->
+      [ nameserver_prefix ^ (Ipaddr.to_string server.Server.address.Address.ip) ^ "#" ^ (string_of_int server.Server.address.Address.port) ]
+      @ (if server.Server.zones <> Domain.Set.empty then [ zone_prefix ^ (String.concat " " @@ List.map Domain.to_string @@ Domain.Set.elements server.Server.zones) ] else [])
+      @ acc
+    ) t.servers [] in
+  let search = List.map
+    (fun search ->
+      search_prefix ^ search
+    ) t.search in
+  String.concat "\n" (nameservers @ search)
 
 module Unix = struct
   let of_resolv_conf txt =

--- a/lib/dns_forward_config.mli
+++ b/lib/dns_forward_config.mli
@@ -50,4 +50,11 @@ end
 type t = Server.Set.t [@@deriving sexp]
 (** Upstream DNS servers *)
 
+val of_string: string -> (t, [ `Msg of string ]) Result.result
+val to_string: t -> string
+
 val compare: t -> t -> int
+
+module Unix: sig
+  val of_resolv_conf: string -> (t, [ `Msg of string ]) Result.result
+end

--- a/lib/dns_forward_config.mli
+++ b/lib/dns_forward_config.mli
@@ -49,8 +49,8 @@ end
 
 type t = {
   servers: Server.Set.t;
+  search: string list;
 } [@@deriving sexp]
-(** Upstream DNS servers *)
 
 val of_string: string -> (t, [ `Msg of string ]) Result.result
 val to_string: t -> string

--- a/lib/dns_forward_config.mli
+++ b/lib/dns_forward_config.mli
@@ -47,7 +47,9 @@ module Server: sig
   module Map: Map.S with type key = t
 end
 
-type t = Server.Set.t [@@deriving sexp]
+type t = {
+  servers: Server.Set.t;
+} [@@deriving sexp]
 (** Upstream DNS servers *)
 
 val of_string: string -> (t, [ `Msg of string ]) Result.result

--- a/lib/dns_forward_resolver.ml
+++ b/lib/dns_forward_resolver.ml
@@ -79,7 +79,7 @@ module Make(Client: Dns_forward_s.RPC_CLIENT)(Time: V1_LWT.TIME) = struct
       or_fail_msg @@ Client.connect server.Dns_forward_config.Server.address
       >>= fun client ->
       Lwt.return (server, client)
-    ) (Dns_forward_config.Server.Set.elements config)
+    ) (Dns_forward_config.Server.Set.elements config.Dns_forward_config.servers)
     >>= fun connections ->
     Lwt.return { connections; local_names_cb; timeout }
 

--- a/lib_test/test.ml
+++ b/lib_test/test.ml
@@ -81,10 +81,11 @@ let test_forwarder_zone () =
     (* a resolver which uses both servers *)
     let module R = Dns_forward.Resolver.Make(Rpc)(Time) in
     let open Dns_forward.Config in
-    let config = Server.Set.of_list [
+    let servers = Server.Set.of_list [
       { Server.address = foo_address; zones = Domain.Set.add [ "foo" ] Domain.Set.empty };
       { Server.address = bar_address; zones = Domain.Set.empty }
     ] in
+    let config = { servers } in
     let open Lwt.Infix in
     R.create config
     >>= fun r ->
@@ -132,9 +133,10 @@ let test_local_lookups () =
     >>= fun () ->
     let module R = Dns_forward.Resolver.Make(Rpc)(Time) in
     let open Dns_forward.Config in
-    let config = Server.Set.of_list [
+    let servers = Server.Set.of_list [
       { Server.address = public_address; zones = Domain.Set.empty };
     ] in
+    let config = { servers } in
     let open Lwt.Infix in
     let local_names_cb question =
       let open Dns.Packet in
@@ -188,9 +190,10 @@ let test_tcp_multiplexing () =
     >>= fun () ->
     let module R = Dns_forward.Resolver.Make(Proto_client)(Time) in
     let open Dns_forward.Config in
-    let config = Server.Set.of_list [
+    let servers = Server.Set.of_list [
       { Server.address = public_address; zones = Domain.Set.empty };
     ] in
+    let config = { servers } in
     let open Lwt.Infix in
     R.create config
     >>= fun r ->

--- a/lib_test/test.ml
+++ b/lib_test/test.ml
@@ -85,7 +85,7 @@ let test_forwarder_zone () =
       { Server.address = foo_address; zones = Domain.Set.add [ "foo" ] Domain.Set.empty };
       { Server.address = bar_address; zones = Domain.Set.empty }
     ] in
-    let config = { servers } in
+    let config = { servers; search = [] } in
     let open Lwt.Infix in
     R.create config
     >>= fun r ->
@@ -136,7 +136,7 @@ let test_local_lookups () =
     let servers = Server.Set.of_list [
       { Server.address = public_address; zones = Domain.Set.empty };
     ] in
-    let config = { servers } in
+    let config = { servers; search = [] } in
     let open Lwt.Infix in
     let local_names_cb question =
       let open Dns.Packet in
@@ -193,7 +193,7 @@ let test_tcp_multiplexing () =
     let servers = Server.Set.of_list [
       { Server.address = public_address; zones = Domain.Set.empty };
     ] in
-    let config = { servers } in
+    let config = { servers; search = [] } in
     let open Lwt.Infix in
     R.create config
     >>= fun r ->

--- a/lib_test/test.ml
+++ b/lib_test/test.ml
@@ -255,9 +255,37 @@ let test_forwarder_set = [
   "Local names resolve ok", `Quick, test_local_lookups;
 ]
 
+open Dns_forward.Config
+
+let config_examples = [
+  "nameserver 10.0.0.2\nnameserver 1.2.3.4#54\nsearch a b c",
+  { servers = Server.Set.of_list [
+    { Server.address = { Address.ip = Ipaddr.V4 (Ipaddr.V4.of_string_exn "10.0.0.2"); port = 53 }; zones = Domain.Set.empty };
+    { Server.address = { Address.ip = Ipaddr.V4 (Ipaddr.V4.of_string_exn "1.2.3.4"); port = 54 }; zones = Domain.Set.empty };
+    ]; search = [ "a"; "b"; "c" ]
+  };
+  "nameserver 10.0.0.2\n",
+  { servers = Server.Set.of_list [
+    { Server.address = { Address.ip = Ipaddr.V4 (Ipaddr.V4.of_string_exn "10.0.0.2"); port = 53 }; zones = Domain.Set.empty };
+    ]; search = []
+  };
+]
+
+let test_parse_config txt expected () =
+  match of_string txt with
+  | Result.Error (`Msg m) -> failwith m
+  | Result.Ok x ->
+    if compare expected x <> 0
+    then failwith ("failed to parse " ^ txt)
+
+let test_config = List.map (fun (txt, expected) ->
+  "DNS " ^ (String.escaped txt), `Quick, test_parse_config txt expected
+) config_examples
+
 let () =
   Alcotest.run "dns-forward" [
     "Test infrastructure", test_infra_set;
     "Test forwarding", test_forwarder_set;
     "Test protocols", test_protocol_set;
+    "Test config parsing", test_config;
   ]


### PR DESCRIPTION
- add parser and printer for a human-readable configuration format
- add parser for Unix `/etc/resolv.conf` format