### PR TITLE
Add an RPC-level per-message callback

### DIFF
--- a/lib/dns_forward.mli
+++ b/lib/dns_forward.mli
@@ -258,8 +258,14 @@ module Resolver: sig
   module type S = sig
     type t
 
+    type address = Config.Address.t
+
+    type message_cb = src:address -> dst:address -> buf:Cstruct.t -> unit Lwt.t
+    (** A callback called per message, which permits recording and analysis *)
+
     val create:
       ?local_names_cb:(Dns.Packet.question -> Dns.Packet.rr list option Lwt.t) ->
+      ?message_cb:message_cb ->
       ?timeout:float ->
       Config.t -> t Lwt.t
     (** Construct a resolver given some configuration *)

--- a/lib/dns_forward.mli
+++ b/lib/dns_forward.mli
@@ -45,6 +45,10 @@ module Flow: sig
     val connect: ?read_buffer_size:int -> address -> flow Error.t
     (** [connect address] creates a connection to [address] and returns
         he connected flow. *)
+
+    val getclientname: flow -> address
+    (** Query the address the client is bound to *)
+
   end
   module type Server = sig
     type server
@@ -189,7 +193,10 @@ module Rpc: sig
       type address = Config.Address.t
       (** The address of the remote endpoint *)
 
-      val connect: address -> t Error.t
+      type message_cb = src:address -> dst:address -> buf:Cstruct.t -> unit Lwt.t
+      (** A callback called per message, which permits recording and analysis *)
+
+      val connect: ?message_cb:message_cb -> address -> t Error.t
       (** Connect to the remote server *)
 
       val rpc: t -> request -> response Error.t

--- a/lib/dns_forward_lwt_unix.ml
+++ b/lib/dns_forward_lwt_unix.ml
@@ -104,6 +104,8 @@ module Tcp = struct
          errorf "%s: Lwt_unix.connect: caught %s" description (Printexc.to_string e)
       )
 
+  let getclientname t = getsockname "Tcp.getclientname" t.fd
+
   let read t = match t.fd with
     | None -> Lwt.return `Eof
     | Some fd ->
@@ -320,6 +322,8 @@ module Udp = struct
     (try Lwt_unix.bind fd (Lwt_unix.ADDR_INET(Unix.inet_addr_any, 0)) with _ -> ());
     let sockaddr = sockaddr_of_address address in
     Lwt.return (Result.Ok (of_fd ?read_buffer_size sockaddr address fd))
+
+  let getclientname t = getsockname "Udp.getclientname" t.fd
 
   let read t = match t.fd, t.already_read with
     | None, _ -> Lwt.return `Eof

--- a/lib/dns_forward_s.ml
+++ b/lib/dns_forward_s.ml
@@ -27,6 +27,7 @@ module type FLOW_CLIENT = sig
   type address
   val connect: ?read_buffer_size:int -> address
     -> (flow, [ `Msg of string ]) Lwt_result.t
+  val getclientname: flow -> address
 end
 
 module type FLOW_SERVER = sig
@@ -39,25 +40,13 @@ module type FLOW_SERVER = sig
   val shutdown: server -> unit Lwt.t
 end
 
-module type SOCKETS = sig
-  type address = Ipaddr.t * int
-
-  type flow
-
-  include FLOW_CLIENT
-    with type address := address
-     and type flow := flow
-  include FLOW_SERVER
-    with type address := address
-     and type flow := flow
-end
-
 module type RPC_CLIENT = sig
   type request = Cstruct.t
   type response = Cstruct.t
   type address = Dns_forward_config.Address.t
   type t
-  val connect: address -> (t, [ `Msg of string ]) Lwt_result.t
+  type message_cb = src:address -> dst:address -> buf:Cstruct.t -> unit Lwt.t
+  val connect: ?message_cb:message_cb -> address -> (t, [ `Msg of string ]) Lwt_result.t
   val rpc: t -> request -> (response, [ `Msg of string ]) Lwt_result.t
   val disconnect: t -> unit Lwt.t
 end

--- a/lib/dns_forward_s.ml
+++ b/lib/dns_forward_s.ml
@@ -64,8 +64,11 @@ end
 
 module type RESOLVER = sig
   type t
+  type address = Dns_forward_config.Address.t
+  type message_cb = src:address -> dst:address -> buf:Cstruct.t -> unit Lwt.t
   val create:
     ?local_names_cb:(Dns.Packet.question -> Dns.Packet.rr list option Lwt.t) ->
+    ?message_cb:message_cb ->
     ?timeout:float ->
     Dns_forward_config.t ->
     t Lwt.t

--- a/lib_test/flow.ml
+++ b/lib_test/flow.ml
@@ -35,6 +35,7 @@ type flow = {
   r2l: Cstruct.t Lwt_sequence.t; (* pending data from right to left *)
   mutable r2l_closed: bool;
   r2l_c: unit Lwt_condition.t;
+  client_address: address;
   server_address: address;
 }
 
@@ -45,12 +46,15 @@ let openflow server_address =
   let r2l_c = Lwt_condition.create () in
   let l2r_closed = false in
   let r2l_closed = false in
-  { l2r; r2l; l2r_c; r2l_c; l2r_closed; r2l_closed; server_address }
+  let client_address = Ipaddr.V4 Ipaddr.V4.localhost, 32768 in
+  { l2r; r2l; l2r_c; r2l_c; l2r_closed; r2l_closed; client_address; server_address }
 
 let otherend flow =
   { l2r = flow.r2l; l2r_c = flow.r2l_c; r2l = flow.l2r; r2l_c = flow.l2r_c;
     l2r_closed = flow.r2l_closed; r2l_closed = flow.l2r_closed;
-    server_address = flow.server_address }
+    client_address = flow.server_address; server_address = flow.client_address }
+
+let getclientname flow = flow.client_address
 
 let read flow =
   let open Lwt.Infix in


### PR DESCRIPTION
This will allow other software to record the messages sent and received
here for later analysis.

Note this requires the CLIENT signature to implement `getclientname`
which is similar to `getsockname` for SERVER.

Signed-off-by: David Scott <dave@recoil.org>