### PR TITLE
Remove `getclientname`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+### trunk (unreleased)
+
+- Remove `getclientname` from `Flow.Client`
+- Make the addresses in the `message_cb` functions optional
+
 ### 0.1.0 (2016-10-25)
 
 - Initial version

--- a/lib/dns_forward.mli
+++ b/lib/dns_forward.mli
@@ -45,10 +45,6 @@ module Flow: sig
     val connect: ?read_buffer_size:int -> address -> flow Error.t
     (** [connect address] creates a connection to [address] and returns
         he connected flow. *)
-
-    val getclientname: flow -> address
-    (** Query the address the client is bound to *)
-
   end
   module type Server = sig
     type server
@@ -195,8 +191,10 @@ module Rpc: sig
       type address = Config.Address.t
       (** The address of the remote endpoint *)
 
-      type message_cb = src:address -> dst:address -> buf:Cstruct.t -> unit Lwt.t
-      (** A callback called per message, which permits recording and analysis *)
+      type message_cb = ?src:address -> ?dst:address -> buf:Cstruct.t -> unit -> unit Lwt.t
+      (** A callback called per message, which permits recording and analysis.
+          If an address is unknown (e.g. it is selected by the kernel when routing
+          the packets) then the corresponding argument will be omitted *)
 
       val connect: ?message_cb:message_cb -> address -> t Error.t
       (** Connect to the remote server *)
@@ -262,8 +260,10 @@ module Resolver: sig
 
     type address = Config.Address.t
 
-    type message_cb = src:address -> dst:address -> buf:Cstruct.t -> unit Lwt.t
-    (** A callback called per message, which permits recording and analysis *)
+    type message_cb = ?src:address -> ?dst:address -> buf:Cstruct.t -> unit -> unit Lwt.t
+    (** A callback called per message, which permits recording and analysis.
+        If an address is unknown (e.g. it is selected by the kernel when routing
+        the packets) then the corresponding argument will be omitted *)
 
     val create:
       ?local_names_cb:(Dns.Packet.question -> Dns.Packet.rr list option Lwt.t) ->

--- a/lib/dns_forward.mli
+++ b/lib/dns_forward.mli
@@ -120,6 +120,8 @@ module Config: sig
     }
     (** The address of a DNS server *)
 
+    val to_string: t -> string
+
     include Comparable with type t := t
     module Set: Set.S with type elt = t
     module Map: Map.S with type key = t

--- a/lib/dns_forward_config.ml
+++ b/lib/dns_forward_config.ml
@@ -28,6 +28,7 @@ module Address = struct
       if ip <> 0 then ip else Pervasives.compare a.port b.port
   end
   include M
+  let to_string { ip; port } = Printf.sprintf "%s:%d" (Ipaddr.to_string ip) port
   module Set = Set.Make(M)
   module Map = Map.Make(M)
 end

--- a/lib/dns_forward_config.mli
+++ b/lib/dns_forward_config.mli
@@ -20,6 +20,7 @@ module Address: sig
     ip: Ipaddr.t;
     port: int;
   }
+  val to_string: t -> string
 
   val compare: t -> t -> int
   module Set: Set.S with type elt = t

--- a/lib/dns_forward_lwt_unix.ml
+++ b/lib/dns_forward_lwt_unix.ml
@@ -104,8 +104,6 @@ module Tcp = struct
          errorf "%s: Lwt_unix.connect: caught %s" description (Printexc.to_string e)
       )
 
-  let getclientname t = getsockname "Tcp.getclientname" t.fd
-
   let read t = match t.fd with
     | None -> Lwt.return `Eof
     | Some fd ->
@@ -322,8 +320,6 @@ module Udp = struct
     (try Lwt_unix.bind fd (Lwt_unix.ADDR_INET(Unix.inet_addr_any, 0)) with _ -> ());
     let sockaddr = sockaddr_of_address address in
     Lwt.return (Result.Ok (of_fd ?read_buffer_size sockaddr address fd))
-
-  let getclientname t = getsockname "Udp.getclientname" t.fd
 
   let read t = match t.fd, t.already_read with
     | None, _ -> Lwt.return `Eof

--- a/lib/dns_forward_resolver.ml
+++ b/lib/dns_forward_resolver.ml
@@ -69,7 +69,7 @@ module type S = Dns_forward_s.RESOLVER
 module Make(Client: Dns_forward_s.RPC_CLIENT)(Time: V1_LWT.TIME) = struct
 
   type address = Dns_forward_config.Address.t
-  type message_cb = src:address -> dst:address -> buf:Cstruct.t -> unit Lwt.t
+  type message_cb = ?src:address -> ?dst:address -> buf:Cstruct.t -> unit -> unit Lwt.t
 
   type t = {
     connections: (Dns_forward_config.Server.t * Client.t) list;

--- a/lib/dns_forward_s.ml
+++ b/lib/dns_forward_s.ml
@@ -27,7 +27,6 @@ module type FLOW_CLIENT = sig
   type address
   val connect: ?read_buffer_size:int -> address
     -> (flow, [ `Msg of string ]) Lwt_result.t
-  val getclientname: flow -> address
 end
 
 module type FLOW_SERVER = sig
@@ -45,7 +44,7 @@ module type RPC_CLIENT = sig
   type response = Cstruct.t
   type address = Dns_forward_config.Address.t
   type t
-  type message_cb = src:address -> dst:address -> buf:Cstruct.t -> unit Lwt.t
+  type message_cb = ?src:address -> ?dst:address -> buf:Cstruct.t -> unit -> unit Lwt.t
   val connect: ?message_cb:message_cb -> address -> (t, [ `Msg of string ]) Lwt_result.t
   val rpc: t -> request -> (response, [ `Msg of string ]) Lwt_result.t
   val disconnect: t -> unit Lwt.t
@@ -65,7 +64,7 @@ end
 module type RESOLVER = sig
   type t
   type address = Dns_forward_config.Address.t
-  type message_cb = src:address -> dst:address -> buf:Cstruct.t -> unit Lwt.t
+  type message_cb = ?src:address -> ?dst:address -> buf:Cstruct.t -> unit -> unit Lwt.t
   val create:
     ?local_names_cb:(Dns.Packet.question -> Dns.Packet.rr list option Lwt.t) ->
     ?message_cb:message_cb ->

--- a/lib_test/flow.ml
+++ b/lib_test/flow.ml
@@ -54,8 +54,6 @@ let otherend flow =
     l2r_closed = flow.r2l_closed; r2l_closed = flow.l2r_closed;
     client_address = flow.server_address; server_address = flow.client_address }
 
-let getclientname flow = flow.client_address
-
 let read flow =
   let open Lwt.Infix in
   let rec wait () =

--- a/lib_test/test.ml
+++ b/lib_test/test.ml
@@ -38,8 +38,13 @@ let test_server () =
     S.serve ~address s
     >>= fun () ->
     let expected_dst = ref false in
-    let message_cb ~src:_ ~dst:d ~buf:_ =
-      if Dns_forward.Config.Address.compare address d <> 0 then expected_dst := true;
+    let message_cb ?src:_ ?dst:d ~buf:_ () =
+      ( match d with
+        | Some d ->
+          if Dns_forward.Config.Address.compare address d = 0 then expected_dst := true
+        | None ->
+          ()
+      );
       Lwt.return_unit
     in
     Rpc.connect ~message_cb address
@@ -211,8 +216,13 @@ let test_tcp_multiplexing () =
     F.serve ~address:f_address f
     >>= fun () ->
     let expected_dst = ref false in
-    let message_cb ~src:_ ~dst:d ~buf:_ =
-      if Dns_forward.Config.Address.compare f_address d <> 0 then expected_dst := true;
+    let message_cb ?src:_ ?dst ~buf:_ () =
+      ( match dst with
+        | Some d ->
+          if Dns_forward.Config.Address.compare f_address d = 0 then expected_dst := true
+        | None ->
+          ()
+      );
       Lwt.return_unit
     in
     Proto_client.connect ~message_cb f_address


### PR DESCRIPTION
The original intention was to record the source IP of the outgoing packets in the message recording callback, however we don't actually know the source IP used by the kernel. Typically `getclientname` will return `0.0.0.0`. This PR removes this facility and makes the addresses optional in the callback instead.

See feedback on [docker/vpnkit#132]