### PR TITLE
Use (optional) per-server timeout values

### DIFF
--- a/doc/example.config
+++ b/doc/example.config
@@ -1,6 +1,7 @@
 # a pretend VPN with a private nameserver
 nameserver 8.8.4.4
 zone mirage.io foo.com
+timeout 5
 
 # a default nameserver
 nameserver 8.8.8.8

--- a/lib/dns_forward.mli
+++ b/lib/dns_forward.mli
@@ -138,6 +138,7 @@ module Config: sig
     type t = {
       zones: Domain.Set.t; (** use this server for these specific domains *)
       address: Address.t;
+      timeout: float option; (** a specific timeout to use for this server *)
     }
     (** A single upstream DNS server. If [zones = []] then the server can handle
         all queries; otherwise [zones] is a list of domains that this server

--- a/lib/dns_forward.mli
+++ b/lib/dns_forward.mli
@@ -269,7 +269,6 @@ module Resolver: sig
     val create:
       ?local_names_cb:(Dns.Packet.question -> Dns.Packet.rr list option Lwt.t) ->
       ?message_cb:message_cb ->
-      ?timeout:float ->
       Config.t -> t Lwt.t
     (** Construct a resolver given some configuration *)
 
@@ -279,9 +278,9 @@ module Resolver: sig
     val answer: Cstruct.t -> t -> Cstruct.t Error.t
     (** Process a query by first checking whether the name can be satisfied
         locally via the [local_names_cb] and failing that, sending it to
-        upstream servers according to the resolver configuration. By default
-        the call will timeout after a few seconds, but this can be customised
-        via the [timeout] optional argument. *)
+        upstream servers according to the resolver configuration. The call
+        will block forever if no server with a timeout is chosen; the client
+        should be prepared to timeout and cancel the thread. *)
   end
 
   module Make(Client: Rpc.Client.S)(Time: V1_LWT.TIME): S

--- a/lib/dns_forward_config.ml
+++ b/lib/dns_forward_config.ml
@@ -58,6 +58,7 @@ module Server = struct
     type t = {
       zones: Domain.Set.t;
       address: Address.t;
+      timeout: float option;
     } [@@deriving sexp]
 
     let compare (a: t) (b: t) =
@@ -90,6 +91,7 @@ let compare a b =
 let nameserver_prefix = "nameserver "
 let search_prefix = "search "
 let zone_prefix = "zone "
+let timeout_prefix = "timeout "
 
 let of_string txt =
   let open Astring in
@@ -122,23 +124,25 @@ let of_string txt =
         end else if String.is_prefix ~affix:search_prefix line then begin
           let line = String.with_range ~first:(String.length search_prefix) line in
           (`Search (String.cuts ~sep:" " line)) :: acc
+        end else if String.is_prefix ~affix:timeout_prefix line then begin
+          let line = String.with_range ~first:(String.length timeout_prefix) line in
+          let whitespace = function ' ' | '\r' | '\n' | '\t' -> true | _ -> false in
+          (`Timeout (float_of_string @@ String.trim ~drop:whitespace line)) :: acc
         end else acc
       ) []
     (* Merge the zones and nameservers together *)
     |> List.fold_left
-      (fun (zones_opt, acc) line -> match zones_opt, line with
-        | _, `Zones zones -> (Some zones, acc)
-        | Some zones, `Nameserver (ip, port) ->
+      (fun (zones, timeout, acc) line -> match zones, timeout, line with
+        | _, timeout, `Zones zones -> zones, timeout, acc
+        | zones, _, `Timeout timeout -> zones, Some timeout, acc
+        | zones, timeout, `Nameserver (ip, port) ->
           let zones = List.map (String.cuts ~sep:"." ?rev:None ?empty:None) zones |> Domain.Set.of_list in
-          let server = { Server.address = { Address.ip; port }; zones } in
-          None, { acc with servers = Server.Set.add server acc.servers }
-        | None, `Nameserver (ip, port) ->
-          let server = { Server.address = { Address.ip; port }; zones = Domain.Set.empty } in
-          None, { acc with servers = Server.Set.add server acc.servers }
-        | _, `Search search ->
-          zones_opt, { acc with search }
-      ) (None, { servers = Server.Set.empty; search = [] })
-    |> snd |> fun x -> Result.Ok x
+          let server = { Server.address = { Address.ip; port }; zones; timeout } in
+          [], None, { acc with servers = Server.Set.add server acc.servers }
+        | _, _, `Search search ->
+          zones, timeout, { acc with search }
+      ) ([], None, { servers = Server.Set.empty; search = [] })
+    |> (fun (_, _, x) -> Result.Ok x)
   with e -> Result.Error (`Msg (Printf.sprintf "Failed to parse configuration: %s" (Printexc.to_string e)))
 
 let to_string t =
@@ -146,6 +150,7 @@ let to_string t =
     (fun server acc ->
       [ nameserver_prefix ^ (Ipaddr.to_string server.Server.address.Address.ip) ^ "#" ^ (string_of_int server.Server.address.Address.port) ]
       @ (if server.Server.zones <> Domain.Set.empty then [ zone_prefix ^ (String.concat " " @@ List.map Domain.to_string @@ Domain.Set.elements server.Server.zones) ] else [])
+      @ (match server.Server.timeout with None -> [] | Some t -> [ timeout_prefix ^ (string_of_float t) ])
       @ acc
     ) t.servers [] in
   let search = List.map
@@ -171,9 +176,9 @@ module Unix = struct
       ) [] lines in
     let servers = List.fold_left (fun acc x -> match x with
       | KeywordValue.Nameserver(ip, Some port) ->
-        Server.Set.add { Server.address = { Address.ip; port }; zones = Domain.Set.empty } acc
+        Server.Set.add { Server.address = { Address.ip; port }; zones = Domain.Set.empty; timeout = None } acc
       | KeywordValue.Nameserver(ip, None) ->
-        Server.Set.add { Server.address = { Address.ip; port = 53 }; zones = Domain.Set.empty } acc
+        Server.Set.add { Server.address = { Address.ip; port = 53 }; zones = Domain.Set.empty; timeout = None } acc
       | _ -> acc
     ) Server.Set.empty config in
     let search = List.fold_left (fun acc x -> match x with

--- a/lib/dns_forward_config.mli
+++ b/lib/dns_forward_config.mli
@@ -39,8 +39,9 @@ end
 
 module Server: sig
   type t = {
-    zones: Domain.Set.t; (** use this server for these specific domains *)
+    zones: Domain.Set.t;
     address: Address.t;
+    timeout: float option;
   }
   (** A single upstream DNS server *)
 

--- a/lib/dns_forward_free_id.ml
+++ b/lib/dns_forward_free_id.ml
@@ -31,18 +31,20 @@ let make ?(max_id = 512) () =
   let free_ids_c = Lwt_condition.create () in
   { free_ids; free_ids_c }
 
-let put t id =
-  t.free_ids <- IntSet.add id t.free_ids;
-  Lwt_condition.signal t.free_ids_c ()
-
-let rec get t =
+let rec with_id t f =
   let open Lwt.Infix in
   if t.free_ids = IntSet.empty then begin
     Lwt_condition.wait t.free_ids_c
     >>= fun () ->
-    get t
+    with_id t f
   end else begin
     let free_id = IntSet.min_elt t.free_ids in
     t.free_ids <- IntSet.remove free_id t.free_ids;
-    Lwt.return free_id
+    Lwt.finalize
+      (fun () -> f free_id)
+      (fun () ->
+        t.free_ids <- IntSet.add free_id t.free_ids;
+        Lwt_condition.signal t.free_ids_c ();
+        Lwt.return_unit
+      )
   end

--- a/lib/dns_forward_free_id.mli
+++ b/lib/dns_forward_free_id.mli
@@ -21,9 +21,5 @@ type t
 val make: ?max_id:int -> unit -> t
 (** Construct a free set with the given maximum *)
 
-val get: t -> int Lwt.t
-(** Get a free id. This will block until there is an element available.
-    Caller must guarantee to call [put] on this id or else there will be a leak *)
-
-val put: t -> int -> unit
-(** Put the result of [get] back in the free set *)
+val with_id: t -> (int -> 'a Lwt.t) -> 'a Lwt.t
+(** [with_id t f] waits for an id to become free and then calls [f id] with it *)

--- a/lib/dns_forward_resolver.ml
+++ b/lib/dns_forward_resolver.ml
@@ -62,6 +62,10 @@ let or_fail_msg m = m >>= function
   | Result.Error (`Msg m) -> Lwt.fail (Failure m)
   | Result.Ok x -> Lwt.return x
 
+let or_option m = m >>= function
+  | Result.Error _ -> Lwt.return None
+  | Result.Ok x -> Lwt.return (Some x)
+
 module type S = Dns_forward_s.RESOLVER
 
 module Make(Client: Dns_forward_s.RPC_CLIENT)(Time: V1_LWT.TIME) = struct
@@ -72,17 +76,16 @@ module Make(Client: Dns_forward_s.RPC_CLIENT)(Time: V1_LWT.TIME) = struct
   type t = {
     connections: (Dns_forward_config.Server.t * Client.t) list;
     local_names_cb: (Dns.Packet.question -> Dns.Packet.rr list option Lwt.t);
-    timeout: float;
   }
 
-  let create ?(local_names_cb=fun _ -> Lwt.return_none) ?message_cb ?(timeout=2.0) config =
+  let create ?(local_names_cb=fun _ -> Lwt.return_none) ?message_cb config =
     Lwt_list.map_s (fun server ->
       or_fail_msg @@ Client.connect ?message_cb server.Dns_forward_config.Server.address
       >>= fun client ->
       Lwt.return (server, client)
     ) (Dns_forward_config.Server.Set.elements config.Dns_forward_config.servers)
     >>= fun connections ->
-    Lwt.return { connections; local_names_cb; timeout }
+    Lwt.return { connections; local_names_cb }
 
   let destroy t =
     Lwt_list.iter_s (fun (_, c) -> Client.disconnect c) t.connections
@@ -117,12 +120,14 @@ module Make(Client: Dns_forward_s.RPC_CLIENT)(Time: V1_LWT.TIME) = struct
           let open Dns_forward_config in
           let _, client = List.find (fun (s, _) -> s = server) t.connections in
           Log.debug (fun f -> f "forwarding to server %s:%d" (Ipaddr.to_string server.Server.address.Address.ip) server.Server.address.Address.port);
-          or_fail_msg @@ Client.rpc client buffer
-          >>= fun reply ->
-          Lwt.return (Some reply) in
+
+          let request = or_option @@ Client.rpc client buffer in
+          match server.Server.timeout with
+          | None -> request
+          | Some t -> Lwt.pick [ (Time.sleep t >>= fun () -> Lwt.return None); request ] in
 
         (* Pick the first reply to come back, or timeout *)
-        ( Lwt.pick @@ (Time.sleep t.timeout >>= fun () -> Lwt.return None) :: (List.map rpc servers)
+        ( Lwt.pick @@ List.map rpc servers
           >>= function
           | None -> Lwt_result.fail (`Msg "no response within the timeout")
           | Some reply -> Lwt_result.return reply

--- a/lib/dns_forward_rpc.ml
+++ b/lib/dns_forward_rpc.ml
@@ -55,14 +55,11 @@ module Client = struct
           match t with
           | { rw = Some rw; _ } as t ->
             t.rw <- None;
-            let tbl = Hashtbl.copy t.wakeners in
-            Hashtbl.clear t.wakeners;
             let error = Result.Error (`Msg "connection to server was closed") in
             Hashtbl.iter (fun id u ->
               Log.err (fun f -> f "disconnect: failing request with id %d" id);
-              Dns_forward_free_id.put t.free_ids id;
               Lwt.wakeup_later u error
-            ) tbl;
+            ) t.wakeners;
             Packet.close rw
           | _ -> Lwt.return_unit
         )
@@ -87,8 +84,6 @@ module Client = struct
             let client_id = response.Dns.Packet.id in
             if Hashtbl.mem t.wakeners client_id then begin
               let u = Hashtbl.find t.wakeners client_id in
-              Hashtbl.remove t.wakeners client_id;
-              Dns_forward_free_id.put t.free_ids client_id;
               Lwt.wakeup_later u (Result.Ok buffer)
             end else begin
               Log.err (fun f -> f "failed to find a wakener for id %d" client_id);
@@ -141,67 +136,73 @@ module Client = struct
            client. Since we are multiplexing requests to a single server we need
            to track used/unused ids on the link to the server and remember the
            mapping to the client. *)
-        let open Lwt.Infix in
+
         (* The id whose scope is the link to the client *)
         let client_id = request.Dns.Packet.id in
         (* The id whose scope is the link to the server *)
-        Dns_forward_free_id.get t.free_ids
-        >>= fun free_id ->
-        (* Copy the buffer since this function will be run in parallel with the
-           same buffer *)
-        let buffer =
-          let tmp = Cstruct.create (Cstruct.len buffer) in
-          Cstruct.blit buffer 0 tmp 0 (Cstruct.len buffer);
-          tmp in
-        (* Rewrite the query id before forwarding *)
-        Cstruct.BE.set_uint16 buffer 0 free_id;
-        Log.debug (fun f -> f "mapping DNS id %d -> %d" client_id free_id);
+        Dns_forward_free_id.with_id t.free_ids
+          (fun free_id ->
+            Lwt.finalize
+              (fun () ->
+                (* Copy the buffer since this function will be run in parallel with the
+                   same buffer *)
+                let buffer =
+                  let tmp = Cstruct.create (Cstruct.len buffer) in
+                  Cstruct.blit buffer 0 tmp 0 (Cstruct.len buffer);
+                  tmp in
+                (* Rewrite the query id before forwarding *)
+                Cstruct.BE.set_uint16 buffer 0 free_id;
+                Log.debug (fun f -> f "mapping DNS id %d -> %d" client_id free_id);
 
-        let th, u = Lwt.task () in
-        Hashtbl.replace t.wakeners free_id u;
+                let th, u = Lwt.task () in
+                Hashtbl.replace t.wakeners free_id u;
 
-        (* If we fail to connect, return the error *)
-        let open Lwt.Infix in
-        begin
-          let open Lwt_result.Infix in
-          get_rw t
-          >>= fun rw ->
-          let open Lwt.Infix in
-          t.message_cb ~dst:t.address ~buf:buffer ()
-          >>= fun () ->
-          (* An existing connection to the server might have been closed by the server;
-             therefore if we fail to write the request, reconnect and try once more. *)
-          Packet.write rw buffer
-          >>= function
-          | Result.Ok () ->
-            Lwt_result.return ()
-          | Result.Error (`Msg m) ->
-            Log.info (fun f -> f "caught %s writing request, attempting to reconnect" m);
-            disconnect t
-            >>= fun () ->
-            let open Lwt_result.Infix in
-            get_rw t
-            >>= fun rw ->
-            let open Lwt.Infix in
-            t.message_cb ~dst:t.address ~buf:buffer ()
-            >>= fun () ->
-            Packet.write rw buffer
-        end
-        >>= function
-        | Result.Error (`Msg m) ->
-          Hashtbl.remove t.wakeners free_id;
-          Dns_forward_free_id.put t.free_ids free_id;
-          Lwt_result.fail (`Msg m)
-        | Result.Ok () ->
-          let open Lwt_result.Infix in
-          th (* will be woken up by the dispatcher *)
-          >>= fun buf ->
-          let open Lwt.Infix in
-          t.message_cb ~src:t.address ~buf ()
-          >>= fun () ->
-          (* Rewrite the query id back to the original *)
-          Cstruct.BE.set_uint16 buf 0 client_id;
-          Lwt_result.return buf
+                (* If we fail to connect, return the error *)
+                let open Lwt.Infix in
+                begin
+                  let open Lwt_result.Infix in
+                  get_rw t
+                  >>= fun rw ->
+                  let open Lwt.Infix in
+                  t.message_cb ~dst:t.address ~buf:buffer ()
+                  >>= fun () ->
+                  (* An existing connection to the server might have been closed by the server;
+                     therefore if we fail to write the request, reconnect and try once more. *)
+                  Packet.write rw buffer
+                  >>= function
+                  | Result.Ok () ->
+                    Lwt_result.return ()
+                  | Result.Error (`Msg m) ->
+                    Log.info (fun f -> f "caught %s writing request, attempting to reconnect" m);
+                    disconnect t
+                    >>= fun () ->
+                    let open Lwt_result.Infix in
+                    get_rw t
+                    >>= fun rw ->
+                    let open Lwt.Infix in
+                    t.message_cb ~dst:t.address ~buf:buffer ()
+                    >>= fun () ->
+                    Packet.write rw buffer
+                end
+                >>= function
+                | Result.Error (`Msg m) ->
+                  Lwt_result.fail (`Msg m)
+                | Result.Ok () ->
+                  let open Lwt_result.Infix in
+                  th (* will be woken up by the dispatcher *)
+                  >>= fun buf ->
+                  let open Lwt.Infix in
+                  t.message_cb ~src:t.address ~buf ()
+                  >>= fun () ->
+                  (* Rewrite the query id back to the original *)
+                  Cstruct.BE.set_uint16 buf 0 client_id;
+                  Lwt_result.return buf
+            ) (fun () ->
+              (* This happens on cancel, disconnect, successful response *)
+              Hashtbl.remove t.wakeners free_id;
+              Lwt.return_unit
+            )
+        )
   end
 end
 

--- a/lib/dns_forward_rpc.ml
+++ b/lib/dns_forward_rpc.ml
@@ -238,8 +238,6 @@ module Server = struct
           Packet.read rw
           >>= fun request ->
           (* FIXME: need to run these in the background *)
-          (* FIXME: need to rewrite transaction IDs if the requests come from
-             different resolvers *)
           let open Lwt.Infix in
           cb request
           >>= function

--- a/lib/dns_forward_s.ml
+++ b/lib/dns_forward_s.ml
@@ -67,7 +67,6 @@ module type RESOLVER = sig
   val create:
     ?local_names_cb:(Dns.Packet.question -> Dns.Packet.rr list option Lwt.t) ->
     ?message_cb:message_cb ->
-    ?timeout:float ->
     Dns_forward_config.t ->
     t Lwt.t
   val destroy: t -> unit Lwt.t

--- a/lib_test/server.ml
+++ b/lib_test/server.ml
@@ -21,13 +21,17 @@ module Make(Server: Rpc.Server.S) = struct
   type t = {
     names: (string * Ipaddr.t) list;
     mutable nr_queries: int;
+    delay: float;
   }
-  let make names = { names; nr_queries = 0 }
+  let make ?(delay=0.) names = { names; nr_queries = 0; delay }
 
   let get_nr_queries { nr_queries; _ } = nr_queries
 
   let answer buffer t =
     t.nr_queries <- t.nr_queries + 1;
+    let open Lwt.Infix in
+    Lwt_unix.sleep t.delay
+    >>= fun () ->
     let len = Cstruct.len buffer in
     let buf = Dns.Buf.of_cstruct buffer in
     match Dns.Protocol.Server.parse (Dns.Buf.sub buf 0 len) with

--- a/lib_test/server.mli
+++ b/lib_test/server.mli
@@ -20,8 +20,10 @@ module Make(Server: Rpc.Server.S): sig
   type t
   (** A DNS server for testing *)
 
-  val make: (string * Ipaddr.t) list -> t
-  (** Construct a server with a fixed set of name mappings *)
+  val make: ?delay:float -> (string * Ipaddr.t) list -> t
+  (** Construct a server with a fixed set of name mappings. If the ?delay
+      argument is provided then an artificial delay will be added before all
+      responses. *)
 
   val serve: address: Config.Address.t -> t -> unit Error.t
   (** Serve requests on the given IP and port forever *)

--- a/lib_test/test.ml
+++ b/lib_test/test.ml
@@ -93,8 +93,8 @@ let test_forwarder_zone () =
     let module R = Dns_forward.Resolver.Make(Rpc)(Time) in
     let open Dns_forward.Config in
     let servers = Server.Set.of_list [
-      { Server.address = foo_address; zones = Domain.Set.add [ "foo" ] Domain.Set.empty };
-      { Server.address = bar_address; zones = Domain.Set.empty }
+      { Server.address = foo_address; zones = Domain.Set.add [ "foo" ] Domain.Set.empty; timeout = None };
+      { Server.address = bar_address; zones = Domain.Set.empty; timeout = None }
     ] in
     let config = { servers; search = [] } in
     let open Lwt.Infix in
@@ -145,7 +145,7 @@ let test_local_lookups () =
     let module R = Dns_forward.Resolver.Make(Rpc)(Time) in
     let open Dns_forward.Config in
     let servers = Server.Set.of_list [
-      { Server.address = public_address; zones = Domain.Set.empty };
+      { Server.address = public_address; zones = Domain.Set.empty; timeout = None };
     ] in
     let config = { servers; search = [] } in
     let open Lwt.Infix in
@@ -202,7 +202,7 @@ let test_tcp_multiplexing () =
     let module R = Dns_forward.Resolver.Make(Proto_client)(Time) in
     let open Dns_forward.Config in
     let servers = Server.Set.of_list [
-      { Server.address = public_address; zones = Domain.Set.empty };
+      { Server.address = public_address; zones = Domain.Set.empty; timeout = None };
     ] in
     let config = { servers; search = [] } in
     let open Lwt.Infix in
@@ -286,27 +286,30 @@ open Dns_forward.Config
 let config_examples = [
   "nameserver 10.0.0.2\nnameserver 1.2.3.4#54\nsearch a b c",
   { servers = Server.Set.of_list [
-    { Server.address = { Address.ip = Ipaddr.V4 (Ipaddr.V4.of_string_exn "10.0.0.2"); port = 53 }; zones = Domain.Set.empty };
-    { Server.address = { Address.ip = Ipaddr.V4 (Ipaddr.V4.of_string_exn "1.2.3.4"); port = 54 }; zones = Domain.Set.empty };
+    { Server.address = { Address.ip = Ipaddr.V4 (Ipaddr.V4.of_string_exn "10.0.0.2"); port = 53 }; zones = Domain.Set.empty; timeout = None };
+    { Server.address = { Address.ip = Ipaddr.V4 (Ipaddr.V4.of_string_exn "1.2.3.4"); port = 54 }; zones = Domain.Set.empty; timeout = None };
     ]; search = [ "a"; "b"; "c" ]
   };
   "nameserver 10.0.0.2\n",
   { servers = Server.Set.of_list [
-    { Server.address = { Address.ip = Ipaddr.V4 (Ipaddr.V4.of_string_exn "10.0.0.2"); port = 53 }; zones = Domain.Set.empty };
+    { Server.address = { Address.ip = Ipaddr.V4 (Ipaddr.V4.of_string_exn "10.0.0.2"); port = 53 }; zones = Domain.Set.empty; timeout = None };
     ]; search = []
   };
   String.concat "\n" [
     "# a pretend VPN zone with a private nameserver";
     "nameserver 1.2.3.4";
     "zone mirage.io foo.com";
+    "timeout 5";
     "";
     "# a default nameserver";
     "nameserver 8.8.8.8";
   ], {
     servers = Server.Set.of_list [
-      { Server.address = { Address.ip = Ipaddr.V4 (Ipaddr.V4.of_string_exn "8.8.8.8"); port = 53 }; zones = Domain.Set.empty };
+      { Server.address = { Address.ip = Ipaddr.V4 (Ipaddr.V4.of_string_exn "8.8.8.8"); port = 53 }; zones = Domain.Set.empty; timeout = None };
       { Server.address = { Address.ip = Ipaddr.V4 (Ipaddr.V4.of_string_exn "1.2.3.4"); port = 53 };
-        zones = Domain.Set.of_list [ [ "mirage"; "io" ]; [ "foo"; "com" ] ]};
+        zones = Domain.Set.of_list [ [ "mirage"; "io" ]; [ "foo"; "com" ] ];
+        timeout = None
+      };
     ]; search = [];
   };
 ]

--- a/lib_test/test.ml
+++ b/lib_test/test.ml
@@ -70,66 +70,6 @@ module Time = struct
   let sleep = Lwt_unix.sleep
 end
 
-let test_forwarder_zone () =
-  Alcotest.(check int) "number of connections" 0 (List.length @@ Rpc.get_connections ());
-  let module S = Server.Make(Rpc) in
-  let foo_public = "8.8.8.8" in
-  let foo_private = "192.168.1.1" in
-  (* a VPN mapping 'foo' to an internal ip *)
-  let foo_server = S.make [ "foo", Ipaddr.of_string_exn foo_private ] in
-  let foo_address = { Dns_forward.Config.Address.ip = Ipaddr.V4 Ipaddr.V4.localhost; port = 1 } in
-  (* a public server mapping 'foo' to a public ip *)
-  let bar_server = S.make [ "foo", Ipaddr.of_string_exn foo_public ] in
-  let bar_address = { Dns_forward.Config.Address.ip = Ipaddr.V4 Ipaddr.V4.localhost; port = 2 } in
-
-  let open Error in
-  match Lwt_main.run begin
-    S.serve ~address:foo_address foo_server
-    >>= fun () ->
-
-    S.serve ~address:bar_address bar_server
-    >>= fun () ->
-    (* a resolver which uses both servers *)
-    let module R = Dns_forward.Resolver.Make(Rpc)(Time) in
-    let open Dns_forward.Config in
-    let servers = Server.Set.of_list [
-      { Server.address = foo_address; zones = Domain.Set.add [ "foo" ] Domain.Set.empty; timeout = None };
-      { Server.address = bar_address; zones = Domain.Set.empty; timeout = None }
-    ] in
-    let config = { servers; search = [] } in
-    let open Lwt.Infix in
-    R.create config
-    >>= fun r ->
-    let module F = Dns_forward.Server.Make(Rpc)(R) in
-    F.create r
-    >>= fun f ->
-    let f_address = { Dns_forward.Config.Address.ip = Ipaddr.V4 Ipaddr.V4.localhost; port = 3 } in
-    let open Error in
-    F.serve ~address:f_address f
-    >>= fun () ->
-    Rpc.connect f_address
-    >>= fun c ->
-    let request = make_a_query (Dns.Name.of_string "foo") in
-    Rpc.rpc c request
-    >>= fun response ->
-    parse_response response
-    >>= fun ipv4 ->
-    Alcotest.(check string) "IPv4" foo_private (Ipaddr.V4.to_string ipv4);
-    let open Lwt.Infix in
-    Rpc.disconnect c
-    >>= fun () ->
-    F.destroy f
-    >>= fun () ->
-    Lwt.return (Result.Ok ())
-  end with
-  | Result.Ok () ->
-    (* the disconnects and close should have removed all the connections: *)
-    Alcotest.(check int) "number of connections" 0 (List.length @@ Rpc.get_connections ());
-    (* The server should have sent the query only to foo and not to bar *)
-    Alcotest.(check int) "foo_server queries" 1 (S.get_nr_queries foo_server);
-    Alcotest.(check int) "bar_server queries" 0 (S.get_nr_queries bar_server);
-  | Result.Error (`Msg m) -> failwith m
-
 let test_local_lookups () =
   Alcotest.(check int) "number of connections" 0 (List.length @@ Rpc.get_connections ());
   match Lwt_main.run begin
@@ -268,6 +208,114 @@ let test_tcp_multiplexing () =
     Alcotest.(check int) "number of connections" 0 (List.length @@ Rpc.get_connections ());
   | Result.Error (`Msg m) -> failwith m
 
+let test_timeout () =
+  Alcotest.(check int) "number of connections" 0 (List.length @@ Rpc.get_connections ());
+  let module Proto_server = Dns_forward.Rpc.Server.Make(Flow)(Dns_forward.Framing.Tcp(Flow))(Time) in
+  let module Proto_client = Dns_forward.Rpc.Client.Make(Flow)(Dns_forward.Framing.Tcp(Flow))(Time) in
+  let module S = Server.Make(Proto_server) in
+  let foo_public = "8.8.8.8" in
+  (* a public server mapping 'foo' to a public ip *)
+  let bar_server = S.make ~delay:60. [ "foo", Ipaddr.of_string_exn foo_public ] in
+  let bar_address = { Dns_forward.Config.Address.ip = Ipaddr.V4 Ipaddr.V4.localhost; port = 8 } in
+
+  let open Error in
+  match Lwt_main.run begin
+    S.serve ~address:bar_address bar_server
+    >>= fun () ->
+    (* a resolver which uses both servers *)
+    let module R = Dns_forward.Resolver.Make(Proto_client)(Time) in
+    let open Dns_forward.Config in
+    let servers = Server.Set.of_list [
+      { Server.address = bar_address; zones = Domain.Set.empty; timeout = Some 0. }
+    ] in
+    let config = { servers; search = [] } in
+    let open Lwt.Infix in
+    R.create config
+    >>= fun r ->
+    let request = make_a_query (Dns.Name.of_string "foo") in
+    let request =
+      R.answer request r
+      >>= function
+      | Result.Ok _ -> failwith "timeout test expected a timeout"
+      | Result.Error _ -> Lwt.return true in
+    let timeout =
+      Lwt_unix.sleep 5.
+      >>= fun () ->
+      Lwt.return false in
+    Lwt.pick [ request; timeout ]
+    >>= fun ok ->
+    if not ok then failwith "server timeout was not respected";
+    R.destroy r
+    >>= fun () ->
+    Lwt.return (Result.Ok ())
+  end with
+  | Result.Ok () ->
+    (* the disconnects and close should have removed all the connections: *)
+    Alcotest.(check int) "number of connections" 0 (List.length @@ Rpc.get_connections ());
+    Alcotest.(check int) "bar_server queries" 1 (S.get_nr_queries bar_server);
+  | Result.Error (`Msg m) -> failwith m
+
+let test_forwarder_zone () =
+  Alcotest.(check int) "number of connections" 0 (List.length @@ Rpc.get_connections ());
+  let module S = Server.Make(Rpc) in
+  let foo_public = "8.8.8.8" in
+  let foo_private = "192.168.1.1" in
+  (* a VPN mapping 'foo' to an internal ip *)
+  let foo_server = S.make [ "foo", Ipaddr.of_string_exn foo_private ] in
+  let foo_address = { Dns_forward.Config.Address.ip = Ipaddr.V4 Ipaddr.V4.localhost; port = 1 } in
+  (* a public server mapping 'foo' to a public ip *)
+  let bar_server = S.make [ "foo", Ipaddr.of_string_exn foo_public ] in
+  let bar_address = { Dns_forward.Config.Address.ip = Ipaddr.V4 Ipaddr.V4.localhost; port = 2 } in
+
+  let open Error in
+  match Lwt_main.run begin
+    S.serve ~address:foo_address foo_server
+    >>= fun () ->
+
+    S.serve ~address:bar_address bar_server
+    >>= fun () ->
+    (* a resolver which uses both servers *)
+    let module R = Dns_forward.Resolver.Make(Rpc)(Time) in
+    let open Dns_forward.Config in
+    let servers = Server.Set.of_list [
+      { Server.address = foo_address; zones = Domain.Set.add [ "foo" ] Domain.Set.empty; timeout = None };
+      { Server.address = bar_address; zones = Domain.Set.empty; timeout = None }
+    ] in
+    let config = { servers; search = [] } in
+    let open Lwt.Infix in
+    R.create config
+    >>= fun r ->
+    let module F = Dns_forward.Server.Make(Rpc)(R) in
+    F.create r
+    >>= fun f ->
+    let f_address = { Dns_forward.Config.Address.ip = Ipaddr.V4 Ipaddr.V4.localhost; port = 3 } in
+    let open Error in
+    F.serve ~address:f_address f
+    >>= fun () ->
+    Rpc.connect f_address
+    >>= fun c ->
+    let request = make_a_query (Dns.Name.of_string "foo") in
+    Rpc.rpc c request
+    >>= fun response ->
+    parse_response response
+    >>= fun ipv4 ->
+    Alcotest.(check string) "IPv4" foo_private (Ipaddr.V4.to_string ipv4);
+    let open Lwt.Infix in
+    Rpc.disconnect c
+    >>= fun () ->
+    F.destroy f
+    >>= fun () ->
+    Lwt.return (Result.Ok ())
+  end with
+  | Result.Ok () ->
+    (* the disconnects and close should have removed all the connections: *)
+    Alcotest.(check int) "number of connections" 0 (List.length @@ Rpc.get_connections ());
+    (* The server should have sent the query only to foo and not to bar *)
+    Alcotest.(check int) "foo_server queries" 1 (S.get_nr_queries foo_server);
+    Alcotest.(check int) "bar_server queries" 0 (S.get_nr_queries bar_server);
+  | Result.Error (`Msg m) -> failwith m
+
+
 let test_infra_set = [
   "Server responds correctly", `Quick, test_server;
 ]
@@ -277,6 +325,7 @@ let test_protocol_set = [
 ]
 
 let test_forwarder_set = [
+  "Per-server timeouts", `Quick, test_timeout;
   "Zone config respected", `Quick, test_forwarder_zone;
   "Local names resolve ok", `Quick, test_local_lookups;
 ]


### PR DESCRIPTION
- remove the `?timeout` argument from `Resolver.answer`: clients should `Lwt.cancel` the thread instead
- support specifying a per-server timeout value