### PR TITLE
Add a cache

### DIFF
--- a/lib/dns-forward.mllib
+++ b/lib/dns-forward.mllib
@@ -8,3 +8,4 @@ Dns_forward_server
 Dns_forward_framing
 Dns_forward_flow
 Dns_forward_s
+Dns_forward_cache

--- a/lib/dns_forward_cache.ml
+++ b/lib/dns_forward_cache.ml
@@ -48,6 +48,10 @@ module Make(Time: V1_LWT.TIME) = struct
       t.cache <- QMap.remove question t.cache;
     end
 
+  let destroy t =
+    QMap.iter (fun _ { timeout; _ } -> Lwt.cancel timeout) t.cache;
+    t.cache <- QMap.empty
+
   let insert t question answers =
     (* If there's an existing binding we'll remove it now *)
     remove t question;

--- a/lib/dns_forward_cache.ml
+++ b/lib/dns_forward_cache.ml
@@ -15,13 +15,59 @@
  *
  *)
 
-type t = {
-  max_bindings: int;
+(* Pervasives.compare is ok because the question consists of a record of
+   constant constructors and a string list. Ideally ocaml-dns would provide
+   nice `compare` functions. *)
+module QMap = Map.Make(struct type t = Dns.Packet.question let compare = Pervasives.compare end)
+
+type result = {
+  answers: Dns.Packet.rr list;
+  (* We'll use the Lwt scheduler as a priority queue to expire records, one
+     timeout thread per record. *)
+  timeout: unit Lwt.t;
 }
 
-let make ?(max_bindings=1024) () =
-  { max_bindings }
+module Make(Time: V1_LWT.TIME) = struct
+  type t = {
+    max_bindings: int;
+    mutable cache: result QMap.t;
+  }
 
-let answer _t _question = None
+  let make ?(max_bindings=1024) () =
+    let cache = QMap.empty in
+    { max_bindings; cache }
 
-let insert _t _question _answer = ()
+  let answer t question =
+    if QMap.mem question t.cache
+    then Some (QMap.find question t.cache).answers
+    else None
+
+  let remove t question =
+    if QMap.mem question t.cache then begin
+      Lwt.cancel (QMap.find question t.cache).timeout;
+      t.cache <- QMap.remove question t.cache;
+    end
+
+  let insert t question answers =
+    (* If there's an existing binding we'll remove it now *)
+    remove t question;
+    (* If we already have the maximum number of bindings then remove one at
+       random *)
+    if QMap.cardinal t.cache >= t.max_bindings then begin
+      let choice = Random.int (QMap.cardinal t.cache) in
+      match QMap.fold (fun question _ (i, existing) ->
+        i + 1, if i = choice then Some question else existing
+      ) t.cache (0, None) with
+      | _, None -> (* should never happen *) ()
+      | _, Some question -> remove t question
+    end;
+    (* We'll expire all records when the lowest TTL is hit to make the code simpler *)
+    let min_ttl = List.fold_left (min) Int32.max_int (List.map (fun rr -> rr.Dns.Packet.ttl) answers) in
+    let timeout =
+      let open Lwt.Infix in
+      Time.sleep (Int32.to_float min_ttl)
+      >>= fun () ->
+      t.cache <- QMap.remove question t.cache;
+      Lwt.return_unit in
+    t.cache <- QMap.add question { answers; timeout } t.cache
+end

--- a/lib/dns_forward_cache.ml
+++ b/lib/dns_forward_cache.ml
@@ -1,0 +1,27 @@
+(*
+ * Copyright (C) 2016 David Scott <dave@recoil.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ *)
+
+type t = {
+  max_bindings: int;
+}
+
+let make ?(max_bindings=1024) () =
+  { max_bindings }
+
+let answer _t _question = None
+
+let insert _t _question _answer = ()

--- a/lib/dns_forward_cache.mli
+++ b/lib/dns_forward_cache.mli
@@ -23,6 +23,9 @@ module Make(Time: V1_LWT.TIME): sig
   (** Create an empty cache. If [?max_bindings] is provided then the cache will
       not contain more than the given number of bindings. *)
 
+  val destroy: t -> unit
+  (** Destroy the cache and free associated resources *)
+
   val answer: t -> Dns.Packet.question -> Dns.Packet.rr list option
   (** Look up the answer to the given question in the cache. Returns None if
       the cache has no binding. *)

--- a/lib/dns_forward_cache.mli
+++ b/lib/dns_forward_cache.mli
@@ -15,16 +15,18 @@
  *
  *)
 
-type t
-(** A cache of DNS answers *)
+module Make(Time: V1_LWT.TIME): sig
+  type t
+  (** A cache of DNS answers *)
 
-val make: ?max_bindings:int -> unit -> t
-(** Create an empty cache. If [?max_bindings] is provided then the cache will
-    not contain more than the given number of bindings. *)
+  val make: ?max_bindings:int -> unit -> t
+  (** Create an empty cache. If [?max_bindings] is provided then the cache will
+      not contain more than the given number of bindings. *)
 
-val answer: t -> Dns.Packet.question -> Dns.Packet.rr list option
-(** Look up the answer to the given question in the cache. Returns None if
-    the cache has no binding. *)
+  val answer: t -> Dns.Packet.question -> Dns.Packet.rr list option
+  (** Look up the answer to the given question in the cache. Returns None if
+      the cache has no binding. *)
 
-val insert: t -> Dns.Packet.question -> Dns.Packet.rr list -> unit
-(** Insert the answer to the question into the cache *)
+  val insert: t -> Dns.Packet.question -> Dns.Packet.rr list -> unit
+  (** Insert the answer to the question into the cache *)
+end

--- a/lib/dns_forward_cache.mli
+++ b/lib/dns_forward_cache.mli
@@ -1,0 +1,30 @@
+(*
+ * Copyright (C) 2016 David Scott <dave@recoil.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ *)
+
+type t
+(** A cache of DNS answers *)
+
+val make: ?max_bindings:int -> unit -> t
+(** Create an empty cache. If [?max_bindings] is provided then the cache will
+    not contain more than the given number of bindings. *)
+
+val answer: t -> Dns.Packet.question -> Dns.Packet.rr list option
+(** Look up the answer to the given question in the cache. Returns None if
+    the cache has no binding. *)
+
+val insert: t -> Dns.Packet.question -> Dns.Packet.rr list -> unit
+(** Insert the answer to the question into the cache *)

--- a/lib/dns_forward_resolver.ml
+++ b/lib/dns_forward_resolver.ml
@@ -150,7 +150,7 @@ module Make(Client: Dns_forward_s.RPC_CLIENT)(Time: V1_LWT.TIME) = struct
             let len = Cstruct.len buffer in
             let buf = Dns.Buf.of_cstruct buffer in
             begin match Dns.Protocol.Server.parse (Dns.Buf.sub buf 0 len) with
-            | Some { answers; _ } -> Cache.insert t.cache question answers
+            | Some { answers; _ } -> if answers <> [] then Cache.insert t.cache question answers
             | _ -> ()
             end;
             Lwt_result.return reply

--- a/lib/dns_forward_resolver.ml
+++ b/lib/dns_forward_resolver.ml
@@ -99,6 +99,7 @@ module Make(Client: Dns_forward_s.RPC_CLIENT)(Time: V1_LWT.TIME) = struct
     Lwt.return { connections; local_names_cb; cache }
 
   let destroy t =
+    Cache.destroy t.cache;
     Lwt_list.iter_s (fun (_, c) -> Client.disconnect c) t.connections
 
   let answer buffer t =

--- a/lib/dns_forward_resolver.ml
+++ b/lib/dns_forward_resolver.ml
@@ -147,8 +147,8 @@ module Make(Client: Dns_forward_s.RPC_CLIENT)(Time: V1_LWT.TIME) = struct
           | None -> Lwt_result.fail (`Msg "no response within the timeout")
           | Some reply ->
             (* Add the data to the cache for next time *)
-            let len = Cstruct.len buffer in
-            let buf = Dns.Buf.of_cstruct buffer in
+            let len = Cstruct.len reply in
+            let buf = Dns.Buf.of_cstruct reply in
             begin match Dns.Protocol.Server.parse (Dns.Buf.sub buf 0 len) with
             | Some { answers; _ } -> if answers <> [] then Cache.insert t.cache question answers
             | _ -> ()

--- a/lib_test/server.ml
+++ b/lib_test/server.ml
@@ -60,12 +60,16 @@ module Make(Server: Rpc.Server.S) = struct
     | None ->
       Lwt.return (Result.Error (`Msg "failed to parse request"))
 
+  type server = Server.server
+
   let serve ~address t =
     let open Error in
     Server.bind address
     >>= fun server ->
     Server.listen server (fun buf -> answer buf t)
     >>= fun () ->
-    Lwt.return (Result.Ok ())
+    Lwt.return (Result.Ok server)
+
+  let shutdown = Server.shutdown
 
 end

--- a/lib_test/server.mli
+++ b/lib_test/server.mli
@@ -25,8 +25,14 @@ module Make(Server: Rpc.Server.S): sig
       argument is provided then an artificial delay will be added before all
       responses. *)
 
-  val serve: address: Config.Address.t -> t -> unit Error.t
+  type server
+  (** A running server *)
+
+  val serve: address: Config.Address.t -> t -> server Error.t
   (** Serve requests on the given IP and port forever *)
+
+  val shutdown: server -> unit Lwt.t
+  (** Shutdown the running server *)
 
   val get_nr_queries: t -> int
   (** Return the number of queries which reached this server *)

--- a/lib_test/test.ml
+++ b/lib_test/test.ml
@@ -26,7 +26,7 @@ let parse_response response =
   match pkt.Dns.Packet.answers with
   | [ { Dns.Packet.rdata = Dns.Packet.A ipv4; _ } ] ->
     Lwt.return (Result.Ok ipv4)
-  | _ -> Lwt.return (Result.Error (`Msg "failed to find answers"))
+  | xs -> Lwt.return (Result.Error (`Msg (Printf.sprintf "failed to find answers: [ %s ]" (String.concat "; " (List.map Dns.Packet.rr_to_string xs)))))
 
 let test_server () =
   match Lwt_main.run begin

--- a/lib_test/test.ml
+++ b/lib_test/test.ml
@@ -36,7 +36,7 @@ let test_server () =
     (* The virtual address we run our server on: *)
     let address = { Dns_forward.Config.Address.ip = Ipaddr.V4 Ipaddr.V4.localhost; port = 53 } in
     S.serve ~address s
-    >>= fun () ->
+    >>= fun _ ->
     let expected_dst = ref false in
     let message_cb ?src:_ ?dst:d ~buf:_ () =
       ( match d with
@@ -81,7 +81,7 @@ let test_local_lookups () =
     let public_address = { Dns_forward.Config.Address.ip = Ipaddr.V4 Ipaddr.V4.localhost; port = 4 } in
     let open Error in
     S.serve ~address:public_address public_server
-    >>= fun () ->
+    >>= fun _ ->
     let module R = Dns_forward.Resolver.Make(Rpc)(Time) in
     let open Dns_forward.Config in
     let servers = Server.Set.of_list [
@@ -138,7 +138,7 @@ let test_tcp_multiplexing () =
     let public_address = { Dns_forward.Config.Address.ip = Ipaddr.V4 Ipaddr.V4.localhost; port = 6 } in
     let open Error in
     S.serve ~address:public_address public_server
-    >>= fun () ->
+    >>= fun _ ->
     let module R = Dns_forward.Resolver.Make(Proto_client)(Time) in
     let open Dns_forward.Config in
     let servers = Server.Set.of_list [
@@ -221,7 +221,7 @@ let test_timeout () =
   let open Error in
   match Lwt_main.run begin
     S.serve ~address:bar_address bar_server
-    >>= fun () ->
+    >>= fun _ ->
     (* a resolver which uses both servers *)
     let module R = Dns_forward.Resolver.Make(Proto_client)(Time) in
     let open Dns_forward.Config in
@@ -255,6 +255,51 @@ let test_timeout () =
     Alcotest.(check int) "bar_server queries" 1 (S.get_nr_queries bar_server);
   | Result.Error (`Msg m) -> failwith m
 
+let test_cache () =
+  Alcotest.(check int) "number of connections" 0 (List.length @@ Rpc.get_connections ());
+  let module Proto_server = Dns_forward.Rpc.Server.Make(Flow)(Dns_forward.Framing.Tcp(Flow))(Time) in
+  let module Proto_client = Dns_forward.Rpc.Client.Make(Flow)(Dns_forward.Framing.Tcp(Flow))(Time) in
+  let module S = Server.Make(Proto_server) in
+  let foo_public = "8.8.8.8" in
+  (* a public server mapping 'foo' to a public ip *)
+  let bar_server = S.make [ "foo", Ipaddr.of_string_exn foo_public ] in
+  let bar_address = { Dns_forward.Config.Address.ip = Ipaddr.V4 Ipaddr.V4.localhost; port = 12 } in
+
+  let open Error in
+  match Lwt_main.run begin
+    S.serve ~address:bar_address bar_server
+    >>= fun server ->
+    (* a resolver which uses both servers *)
+    let module R = Dns_forward.Resolver.Make(Proto_client)(Time) in
+    let open Dns_forward.Config in
+    let servers = Server.Set.of_list [
+      { Server.address = bar_address; zones = Domain.Set.empty; timeout_ms = Some 1000; order = 0 }
+    ] in
+    let config = { servers; search = [] } in
+    let open Lwt.Infix in
+    R.create config
+    >>= fun r ->
+    let request = make_a_query (Dns.Name.of_string "foo") in
+    R.answer request r
+    >>= function
+    | Result.Error _ -> failwith "failed initial lookup"
+    | Result.Ok _ ->
+    S.shutdown server
+    >>= fun () ->
+    R.answer request r
+    >>= function
+    | Result.Error (`Msg m) -> failwith ("failed cached lookup: " ^ m)
+    | Result.Ok _ ->
+    R.destroy r
+    >>= fun () ->
+    Lwt.return (Result.Ok ())
+  end with
+  | Result.Ok () ->
+    (* the disconnects and close should have removed all the connections: *)
+    Alcotest.(check int) "number of connections" 0 (List.length @@ Rpc.get_connections ());
+    Alcotest.(check int) "bar_server queries" 1 (S.get_nr_queries bar_server);
+  | Result.Error (`Msg m) -> failwith m
+
 (* One slow private server, one fast public server with different bindings for
    the same name. The order field guarantees that we take the answer from the
    slow private server. *)
@@ -275,9 +320,9 @@ let test_order () =
   let open Error in
   match Lwt_main.run begin
     S.serve ~address:public_address public_server
-    >>= fun () ->
+    >>= fun _ ->
     S.serve ~address:private_address private_server
-    >>= fun () ->
+    >>= fun _ ->
 
     (* a resolver which uses both servers *)
     let module R = Dns_forward.Resolver.Make(Proto_client)(Time) in
@@ -324,10 +369,10 @@ let test_forwarder_zone () =
   let open Error in
   match Lwt_main.run begin
     S.serve ~address:foo_address foo_server
-    >>= fun () ->
+    >>= fun _ ->
 
     S.serve ~address:bar_address bar_server
-    >>= fun () ->
+    >>= fun _ ->
     (* a resolver which uses both servers *)
     let module R = Dns_forward.Resolver.Make(Rpc)(Time) in
     let open Dns_forward.Config in
@@ -383,6 +428,7 @@ let test_forwarder_set = [
   "Zone config respected", `Quick, test_forwarder_zone;
   "Local names resolve ok", `Quick, test_local_lookups;
   "Server order", `Quick, test_order;
+  "Caching", `Quick, test_cache;
 ]
 
 open Dns_forward.Config


### PR DESCRIPTION
It's perfectly legitimate to cache DNS records for up to the TTL. This should help work around transient failures.

- cache up to 1024 bindings
- when full, expire elements at random
- use one background Lwt thread per record to expire it at the TTL