### PR TITLE
Improve the logging

### DIFF
--- a/lib/dns_forward_rpc.ml
+++ b/lib/dns_forward_rpc.ml
@@ -95,7 +95,7 @@ module Client = struct
               with Invalid_argument _ ->
                 Log.warn (fun f -> f "%s %04x: response arrived for DNS request just after disconnection" (to_string t) client_id)
             end else begin
-              Log.err (fun f -> f "%s %04x: failed to find a wakener" (to_string t) client_id);
+              Log.debug (fun f -> f "%s %04x: no wakener: it was probably cancelled" (to_string t) client_id);
             end;
             loop ()
           end

--- a/lib/dns_forward_rpc.ml
+++ b/lib/dns_forward_rpc.ml
@@ -17,7 +17,7 @@
 
 let src =
   let src = Logs.Src.create "Dns_forward" ~doc:"DNS over SOCKETS" in
-  Logs.Src.set_level src (Some Logs.Debug);
+  Logs.Src.set_level src (Some Logs.Info);
   src
 
 module Log = (val Logs.src_log src : Logs.LOG)


### PR DESCRIPTION

- log better when `disconnect` races with receiving (I think this was overall harmless but confusing)
- log the client address and use `%04x` for the request ids