### PR TITLE
All responses should be DNS responses, not queries

### DIFF
--- a/lib/dns_forward_resolver.ml
+++ b/lib/dns_forward_resolver.ml
@@ -117,7 +117,7 @@ module Make(Client: Dns_forward_s.RPC_CLIENT)(Time: V1_LWT.TIME) = struct
         end >>= function
         | Some answers ->
           let id = request.id in
-          let detail = request.detail in
+          let detail = { request.detail with Dns.Packet.qr = Dns.Packet.Response } in
           let questions = request.questions in
           let authorities = [] and additionals = [] in
           let pkt = { id; detail; questions; answers; authorities; additionals } in

--- a/lib_test/server.ml
+++ b/lib_test/server.ml
@@ -49,6 +49,7 @@ module Make(Server: Rpc.Server.S) = struct
             Lwt.return (Result.Error (`Msg "no mapping for name"))
           | Some v4 ->
             let answers = [ { name = q_name; cls = RR_IN; flush = false; ttl = 0l; rdata = A v4 } ] in
+            let detail = { detail with Dns.Packet.qr = Dns.Packet.Response } in
             let pkt = { Dns.Packet.id; detail; questions = request.questions; authorities=[]; additionals; answers } in
             let buf = Dns.Buf.create 1024 in
             let buf = marshal buf pkt in


### PR DESCRIPTION
In the "local names" callback we reflected the `detail` from the request in the response. Unfortunately this includes the `Query` type, while we actually need to send back the `Response` type.

This PR enhances the test cases to find the problem and fixes it.