### PR TITLE
Set the recursion available bit

### DIFF
--- a/lib/dns_forward_resolver.ml
+++ b/lib/dns_forward_resolver.ml
@@ -117,7 +117,7 @@ module Make(Client: Dns_forward_s.RPC_CLIENT)(Time: V1_LWT.TIME) = struct
         end >>= function
         | Some answers ->
           let id = request.id in
-          let detail = { request.detail with Dns.Packet.qr = Dns.Packet.Response } in
+          let detail = { request.detail with Dns.Packet.qr = Dns.Packet.Response; ra = true } in
           let questions = request.questions in
           let authorities = [] and additionals = [] in
           let pkt = { id; detail; questions; answers; authorities; additionals } in

--- a/lib_test/server.ml
+++ b/lib_test/server.ml
@@ -53,7 +53,7 @@ module Make(Server: Rpc.Server.S) = struct
             Lwt.return (Result.Error (`Msg "no mapping for name"))
           | Some v4 ->
             let answers = [ { name = q_name; cls = RR_IN; flush = false; ttl = 0l; rdata = A v4 } ] in
-            let detail = { detail with Dns.Packet.qr = Dns.Packet.Response } in
+            let detail = { detail with Dns.Packet.qr = Dns.Packet.Response; ra = true } in
             let questions = match t.simulate_bad_question with
               | true -> [ bad_question ]
               | false -> request.questions in


### PR DESCRIPTION
We wish to act as a recursive resolver, so we should set the recursion available bit on all our responses. Previously the responses we echoed from upstream would have the bit set, but the results from the cache would not.