### PR TITLE
cache: remember the server address which generated the response

### DIFF
--- a/lib/dns_forward_cache.mli
+++ b/lib/dns_forward_cache.mli
@@ -26,10 +26,10 @@ module Make(Time: V1_LWT.TIME): sig
   val destroy: t -> unit
   (** Destroy the cache and free associated resources *)
 
-  val answer: t -> Dns.Packet.question -> Dns.Packet.rr list option
-  (** Look up the answer to the given question in the cache. Returns None if
-      the cache has no binding. *)
+  val answer: t -> Dns.Packet.question -> (Dns_forward_config.Address.t * Dns.Packet.rr list) list
+  (** Look up the answers to the given question in the cache. Returns all
+      answers received from all servers. *)
 
-  val insert: t -> Dns.Packet.question -> Dns.Packet.rr list -> unit
+  val insert: t -> Dns_forward_config.Address.t -> Dns.Packet.question -> Dns.Packet.rr list -> unit
   (** Insert the answer to the question into the cache *)
 end


### PR DESCRIPTION
The cache now allows individual answers to be `insert`ed per-server
address, and `answer` will return a list of all known
(server address, rr list) pairs.

There is no change to default behaviour since we still only insert
one answer per query. However in future we will cache responses to all
queries we send, even if they don't all agree.

Signed-off-by: David Scott <dave@recoil.org>