### PR TITLE
Make the cache per-server rather than global

### DIFF
--- a/lib/dns_forward_cache.ml
+++ b/lib/dns_forward_cache.ml
@@ -48,11 +48,13 @@ module Make(Time: V1_LWT.TIME) = struct
     let cache = Question.Map.empty in
     { max_bindings; cache }
 
-  let answer t question =
+  let answer t address question =
     if Question.Map.mem question t.cache then begin
       let all = Question.Map.find question t.cache in
-      Address.Map.fold (fun address answer acc -> (address, answer.rrs) :: acc) all []
-    end else []
+      if Address.Map.mem address all
+      then Some (Address.Map.find address all).rrs
+      else None
+    end else None
 
   let remove t question =
     if Question.Map.mem question t.cache then begin

--- a/lib/dns_forward_cache.mli
+++ b/lib/dns_forward_cache.mli
@@ -26,9 +26,9 @@ module Make(Time: V1_LWT.TIME): sig
   val destroy: t -> unit
   (** Destroy the cache and free associated resources *)
 
-  val answer: t -> Dns.Packet.question -> (Dns_forward_config.Address.t * Dns.Packet.rr list) list
-  (** Look up the answers to the given question in the cache. Returns all
-      answers received from all servers. *)
+  val answer: t -> Dns_forward_config.Address.t -> Dns.Packet.question -> Dns.Packet.rr list option
+  (** Look up the answer given by a specific server to a question. Returns
+      None if no answer is cached from that server. *)
 
   val insert: t -> Dns_forward_config.Address.t -> Dns.Packet.question -> Dns.Packet.rr list -> unit
   (** Insert the answer to the question into the cache *)

--- a/lib/dns_forward_resolver.ml
+++ b/lib/dns_forward_resolver.ml
@@ -108,41 +108,53 @@ module Make(Client: Dns_forward_s.RPC_CLIENT)(Time: V1_LWT.TIME) = struct
     let open Dns.Packet in
     match Dns.Protocol.Server.parse (Dns.Buf.sub buf 0 len) with
     | Some ({ questions = [ question ]; _ } as request) ->
+      (* Given a set of answers (resource records), synthesize an answer to the
+         current question. *)
+      let marshal_reply answers =
+        let id = request.id in
+        let detail = { request.detail with Dns.Packet.qr = Dns.Packet.Response } in
+        let questions = request.questions in
+        let authorities = [] and additionals = [] in
+        let pkt = { id; detail; questions; answers; authorities; additionals } in
+        let buf = Dns.Buf.create 1024 in
+        let buf = marshal buf pkt in
+        Cstruct.of_bigarray buf in
+
       (* Look for any local answers to this question *)
       begin
-        begin
-          t.local_names_cb question
-          >>= function
-          | Some x -> Lwt.return (Some x)
-          | None ->
-            (* Second look in the cache *)
-            begin match Cache.answer t.cache question with
-              | (_, x) :: _ -> Lwt.return (Some x)
-              | [] -> Lwt.return None
-            end
-        end >>= function
-        | Some answers ->
-          let id = request.id in
-          let detail = { request.detail with Dns.Packet.qr = Dns.Packet.Response } in
-          let questions = request.questions in
-          let authorities = [] and additionals = [] in
-          let pkt = { id; detail; questions; answers; authorities; additionals } in
-          let buf = Dns.Buf.create 1024 in
-          let buf = marshal buf pkt in
-          Lwt_result.return (Cstruct.of_bigarray buf)
+        t.local_names_cb question
+        >>= function
+        | Some answers -> Lwt_result.return (marshal_reply answers)
         | None ->
-
           (* Possible outcomes are:
              - Some <result>: candidate for returning to the client
              - None: timeout
              - failure: probably a network error *)
           let one_rpc server =
             let open Dns_forward_config in
-            let _, client = List.find (fun (s, _) -> s = server) t.connections in
-            let request = or_option @@ Client.rpc client buffer in
-            match server.Server.timeout_ms with
-            | None -> request
-            | Some t -> Lwt.pick [ (Time.sleep (float_of_int t /. 1000.0) >>= fun () -> Lwt.return None); request ] in
+            let address = server.Server.address in
+            (* Look in the cache *)
+            match Cache.answer t.cache address question with
+            | Some answers -> Lwt.return (Some (marshal_reply answers))
+            | None ->
+              let _, client = List.find (fun (s, _) -> s = server) t.connections in
+              let request = or_option @@ Client.rpc client buffer in
+              begin
+                begin match server.Server.timeout_ms with
+                | None -> request
+                | Some t -> Lwt.pick [ (Time.sleep (float_of_int t /. 1000.0) >>= fun () -> Lwt.return None); request ]
+                end >>= function
+                | None -> Lwt.return None
+                | Some reply ->
+                  (* Insert the reply into the cache *)
+                  let len = Cstruct.len reply in
+                  let buf = Dns.Buf.of_cstruct reply in
+                  begin match Dns.Protocol.Server.parse (Dns.Buf.sub buf 0 len) with
+                  | Some { answers; _ } -> if answers <> [] then Cache.insert t.cache address question answers
+                  | _ -> ()
+                  end;
+                  Lwt.return (Some reply)
+              end in
 
           (* Send the request to all relevant servers in groups. If no response
              is heard from a group, then we proceed to the next group *)
@@ -155,7 +167,7 @@ module Make(Client: Dns_forward_s.RPC_CLIENT)(Time: V1_LWT.TIME) = struct
                   >>= function
                   | Some result ->
                     (* first positive response becomes the result *)
-                    (try Lwt.wakeup_later result_u (Some (server.Dns_forward_config.Server.address, result)) with Invalid_argument _ -> ());
+                    (try Lwt.wakeup_later result_u (Some result) with Invalid_argument _ -> ());
                     Lwt.return_unit
                   | None -> Lwt.return_unit
                 ) servers in
@@ -172,15 +184,7 @@ module Make(Client: Dns_forward_s.RPC_CLIENT)(Time: V1_LWT.TIME) = struct
             ) None (choose_servers (List.map fst t.connections) request)
           >>= function
           | None -> Lwt_result.fail (`Msg "no response within the timeout")
-          | Some (address, reply) ->
-            (* Add the data to the cache for next time *)
-            let len = Cstruct.len reply in
-            let buf = Dns.Buf.of_cstruct reply in
-            begin match Dns.Protocol.Server.parse (Dns.Buf.sub buf 0 len) with
-            | Some { answers; _ } -> if answers <> [] then Cache.insert t.cache address question answers
-            | _ -> ()
-            end;
-            Lwt_result.return reply
+          | Some reply -> Lwt_result.return reply
       end
     | Some { questions = _; _} ->
       Lwt_result.fail (`Msg "cannot handle DNS packets where len(questions)<>1")

--- a/lib/dns_forward_resolver.ml
+++ b/lib/dns_forward_resolver.ml
@@ -173,7 +173,7 @@ module Make(Client: Dns_forward_s.RPC_CLIENT)(Time: V1_LWT.TIME) = struct
                 ) servers in
                 (* Wait until either a positive result or all threads have quit *)
                 let all_quit = Lwt.catch (fun () -> Lwt.join all >>= fun () -> Lwt.return_none) (fun _ -> Lwt.return_none) in
-                Lwt.pick [ all_quit; result_t ]
+                Lwt.choose [ all_quit; result_t ]
                 >>= fun _ ->
                 (* If we have a result, return it *)
                 begin match Lwt.state result_t with


### PR DESCRIPTION
Previously we would consult the cache first for every incoming request. The PR changes the pipeline so we consult the cache on a per-server basis. This is a step on the way towards decoupling the caching of answers from remote servers from the logic which chooses which response to send to the user. Eventually we will be able to do things like: send all requests in parallel, and wait for the responses in order.
