### PR TITLE
Query all servers concurrently

### DIFF
--- a/lib_test/test.ml
+++ b/lib_test/test.ml
@@ -463,8 +463,9 @@ let test_order () =
   | Result.Ok () ->
     (* the disconnects and close should have removed all the connections: *)
     Alcotest.(check int) "number of connections" 0 (List.length @@ Rpc.get_connections ());
+    (* We now query all servers matching a zone *)
     Alcotest.(check int) "private_server queries" 1 (S.get_nr_queries private_server);
-    Alcotest.(check int) "public_server queries" 0 (S.get_nr_queries public_server);
+    Alcotest.(check int) "public_server queries" 1 (S.get_nr_queries public_server);
   | Result.Error (`Msg m) -> failwith m
 
 let test_forwarder_zone () =


### PR DESCRIPTION
Previously we would query servers in groups and take the first response (even if it was `Refused`)

This PR queries all servers concurrently and returns the "best" response where

- any successful resolution is better than any error
- a `NXDomain` is better than an internal error like `Refused`