### PR TITLE
Don't exclude servers with a zone configured

### DIFF
--- a/lib/dns_forward_resolver.ml
+++ b/lib/dns_forward_resolver.ml
@@ -53,8 +53,8 @@ let choose_servers config request =
         (* If any of the configured domains match, send to these servers *)
         matching_servers
       | [] ->
-        (* Otherwise send to all servers with no match *)
-        List.filter (fun server -> server.Server.zones = Domain.Set.empty) config in
+        (* Otherwise send to all servers *)
+        config in
     (* Now we order by the order field *)
     let orders = List.fold_left (fun set server -> IntSet.add server.Server.order set) IntSet.empty all in
     List.map

--- a/lib/dns_forward_resolver.ml
+++ b/lib/dns_forward_resolver.ml
@@ -61,7 +61,8 @@ let choose_servers config request =
       (fun order ->
         List.filter (fun server -> server.Server.order = order) all
       ) (IntSet.elements orders)
-  | _ -> [ [] ]
+    |> List.concat
+  | _ -> []
   end
 
 let or_fail_msg m = m >>= function
@@ -166,8 +167,6 @@ module Make(Client: Dns_forward_s.RPC_CLIENT)(Time: V1_LWT.TIME) = struct
              (if configured).
              Group the servers into lists of equal priorities. *)
           choose_servers (List.map fst t.connections) request
-          |>
-          List.concat
           |>
           (* Send all requests in parallel to minimise the chance of hitting a
              timeout. Positive replies will be cached, but servers which don't


### PR DESCRIPTION
Previously we would match the domain in the request against the zone and
    
1. if there was any match, we would send the request only to matching servers
2. if there was no match, we would send the request only to servers with no zone
    
Rule (1) is good because it prevents the accidental leakage of private DNS names so we keep it.
    
Rule (2) is bad because a server can be needed for general queries: for example consider the situation when there is only one DNS server configured which happens to have a zone.
    
This patch changes rule (2): now if there is no match, we will send the (public) request to all configured servers.