### PR TITLE
Set the Recursion Available bit in cached responses

### DIFF
--- a/lib/dns_forward_resolver.ml
+++ b/lib/dns_forward_resolver.ml
@@ -109,7 +109,7 @@ module Make(Client: Dns_forward_s.RPC_CLIENT)(Time: V1_LWT.TIME) = struct
          current question. *)
       let marshal_reply answers =
         let id = request.id in
-        let detail = { request.detail with Dns.Packet.qr = Dns.Packet.Response } in
+        let detail = { request.detail with Dns.Packet.qr = Dns.Packet.Response; ra = true } in
         let questions = request.questions in
         let authorities = [] and additionals = [] in
         let pkt = { id; detail; questions; answers; authorities; additionals } in


### PR DESCRIPTION
In my experiments using `8.8.8.8` and my local DNS server, if I run `dig +norecurse` I usually get a (cached?) resolved answer with the recursion available bit set. So I think it's correct for us to always reply with the recursion available bit set, meaning that we're advertising the facility (even if it isn't requested).

Signed-off-by: David Scott <dave@recoil.org>