### PR TITLE
Server timeouts

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+### 0.8.2 (2017-03-10)
+
+- add global configuration option `assume-offline-after-drops` which tells the resolver to consider an upstream offline if it fails to respond to this number of queries in a row
+- when a server is offline we continue to send queries to it, but we don't wait for responses. This prevents a bad server making us wait until timeout on every request.
+- we use `Lwt.nchoose_split` to wait for equal-priority results at once: this avoids waiting for requests in arbitrary list order (previously we used `Lwt.fold_left_s`)
+- we resend requests every 1s even if the timeout is longer
+
 ### 0.8.1 (2017-02-06)
 
 - always set the Recursion Available bit from cached responses

--- a/lib/dns_forward.mli
+++ b/lib/dns_forward.mli
@@ -284,7 +284,7 @@ module Resolver: sig
         should be prepared to timeout and cancel the thread. *)
   end
 
-  module Make(Client: Rpc.Client.S)(Time: V1_LWT.TIME): S
+  module Make(Client: Rpc.Client.S)(Time: V1_LWT.TIME)(Clock: V1.CLOCK): S
   (** Construct a DNS resolver which will use the given [Client] Implementation
       to contact upstream servers, and the given [Time] implementation to handle
       timeouts. *)

--- a/lib/dns_forward.mli
+++ b/lib/dns_forward.mli
@@ -156,6 +156,8 @@ module Config: sig
   type t = {
     servers: Server.Set.t; (** Upstream DNS servers *)
     search: string list;   (** Ordered list of domains to search *)
+    assume_offline_after_drops: int option;
+    (** Once this number of drops have happened, assume the server is offline *)
   } [@@deriving sexp]
   (** A DNS configuration *)
 

--- a/lib/dns_forward_config.mli
+++ b/lib/dns_forward_config.mli
@@ -54,6 +54,7 @@ end
 type t = {
   servers: Server.Set.t;
   search: string list;
+  assume_offline_after_drops: int option;
 } [@@deriving sexp]
 
 val of_string: string -> (t, [ `Msg of string ]) Result.result

--- a/lib/dns_forward_lwt_unix.ml
+++ b/lib/dns_forward_lwt_unix.ml
@@ -456,13 +456,31 @@ module Time = struct
   let sleep = Lwt_unix.sleep
 end
 
+module Clock = struct
+  type tm =
+    { tm_sec: int;
+      tm_min: int;
+      tm_hour: int;
+      tm_mday: int;
+      tm_mon: int;
+      tm_year: int;
+      tm_wday: int;
+      tm_yday: int;
+      tm_isdst: bool;
+    }
+
+  let time = Unix.gettimeofday
+
+  let gmtime _ = failwith "gmtime unimplemented"
+end
+
 module R = struct
   open Dns_forward
   module Udp_client = Rpc.Client.Make(Udp)(Framing.Udp(Udp))(Time)
-  module Udp = Resolver.Make(Udp_client)(Time)
+  module Udp = Resolver.Make(Udp_client)(Time)(Clock)
 
   module Tcp_client = Rpc.Client.Make(Tcp)(Framing.Tcp(Tcp))(Time)
-  module Tcp = Resolver.Make(Tcp_client)(Time)
+  module Tcp = Resolver.Make(Tcp_client)(Time)(Clock)
 end
 
 module Server = struct

--- a/lib/dns_forward_lwt_unix.mli
+++ b/lib/dns_forward_lwt_unix.mli
@@ -32,3 +32,5 @@ module Server: sig
   module Tcp: Dns_forward.Server.S with type resolver = Resolver.Tcp.t
   (** A forwarding DNS proxy over TCP *)
 end
+
+module Clock: V1.CLOCK

--- a/lib/dns_forward_resolver.ml
+++ b/lib/dns_forward_resolver.ml
@@ -72,7 +72,7 @@ let or_fail_msg m = m >>= function
 
 module type S = Dns_forward_s.RESOLVER
 
-module Make(Client: Dns_forward_s.RPC_CLIENT)(Time: V1_LWT.TIME) = struct
+module Make(Client: Dns_forward_s.RPC_CLIENT)(Time: V1_LWT.TIME)(Clock: V1.CLOCK) = struct
 
   module Cache = Dns_forward_cache.Make(Time)
 

--- a/lib/dns_forward_resolver.mli
+++ b/lib/dns_forward_resolver.mli
@@ -17,4 +17,4 @@
 
 module type S = Dns_forward_s.RESOLVER
 
-module Make(Client: Dns_forward_s.RPC_CLIENT)(Time: V1_LWT.TIME): S
+module Make(Client: Dns_forward_s.RPC_CLIENT)(Time: V1_LWT.TIME)(Clock: V1.CLOCK): S

--- a/lib_test/fake.ml
+++ b/lib_test/fake.ml
@@ -1,0 +1,66 @@
+(*
+ * Copyright (C) 2017 Docker Inc
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ *)
+
+(* A fake Time and Clock module for testing the timing without having to actually
+   wait. *)
+
+let timeofday = ref 0.
+let c = Lwt_condition.create ()
+
+let advance nsecs =
+  timeofday := !timeofday +. nsecs;
+  Lwt_condition.broadcast c ()
+
+let reset () =
+  timeofday := 0.;
+  Lwt_condition.broadcast c ()
+
+module Time = struct
+  type 'a io = 'a Lwt.t
+
+  let sleep n =
+    let open Lwt.Infix in
+    (* All sleeping is relative to the start of the program for now *)
+    let now = 0. in
+    let rec loop () =
+      if !timeofday > (now +. n) then Lwt.return_unit else begin
+        Lwt_condition.wait c
+        >>= fun () ->
+        loop ()
+      end in
+    loop ()
+end
+
+
+module Clock = struct
+
+  type tm =
+    { tm_sec: int;
+      tm_min: int;
+      tm_hour: int;
+      tm_mday: int;
+      tm_mon: int;
+      tm_year: int;
+      tm_wday: int;
+      tm_yday: int;
+      tm_isdst: bool;
+    }
+
+  let time () = !timeofday
+
+  let gmtime _ = failwith "gmtime unimplemented"
+end

--- a/lib_test/fake.mli
+++ b/lib_test/fake.mli
@@ -1,5 +1,5 @@
 (*
- * Copyright (C) 2016 David Scott <dave@recoil.org>
+ * Copyright (C) 2017 Docker Inc
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -15,18 +15,17 @@
  *
  *)
 
-(** An in-memory FLOW simulation *)
+(** A fake Time and Clock module for testing the timing without having to actually
+    wait. *)
 
-type address = Ipaddr.t * int
+module Time: V1_LWT.TIME
 
-include Dns_forward.Flow.Client
-  with type address := address
-include Dns_forward.Flow.Server
-  with type address := address
-   and type flow := flow
+module Clock: V1.CLOCK
 
-val get_connections: unit -> (address * int) list
-(** Return a list of [server address, number of clients still connected] *)
+val advance: float -> unit
+(** [advance nsecs]: advances the clock by [nsecs]. Note this will make sleeping
+    threads runnable but it will not wait for them to finish or even to run.
+    External synchronisation still needs to be used. *)
 
-val find_free_address: unit -> address
-(** Return an unused address suitable for listening on *)
+val reset: unit -> unit
+(** [reset ()] sets the clock back to the initial value for another test. *)

--- a/lib_test/flow.ml
+++ b/lib_test/flow.ml
@@ -123,6 +123,12 @@ let connect ?read_buffer_size:_ address =
     Lwt.return (Result.Ok flow)
   end else errorf "connect: no server bound to %s" (string_of_address address)
 
+let find_free_address () =
+  let rec loop port =
+    let address = Ipaddr.V4 Ipaddr.V4.localhost, port in
+    if Hashtbl.mem bound address then loop (port + 1) else address  in
+  loop 0
+
 let bind address =
   let listen_cb _ = Lwt.return (Result.Error (`Msg "no callback")) in
   let server = { listen_cb; address } in

--- a/lib_test/test.ml
+++ b/lib_test/test.ml
@@ -93,7 +93,7 @@ let test_local_lookups () =
     let servers = Server.Set.of_list [
       { Server.address = public_address; zones = Domain.Set.empty; timeout_ms = None; order = 0 };
     ] in
-    let config = { servers; search = [] } in
+    let config = { servers; search = []; assume_offline_after_drops = None } in
     let open Lwt.Infix in
     let local_names_cb question =
       let open Dns.Packet in
@@ -150,7 +150,7 @@ let test_tcp_multiplexing () =
     let servers = Server.Set.of_list [
       { Server.address = public_address; zones = Domain.Set.empty; timeout_ms = None; order = 0 };
     ] in
-    let config = { servers; search = [] } in
+    let config = { servers; search = []; assume_offline_after_drops = None } in
     let open Lwt.Infix in
     R.create config
     >>= fun r ->
@@ -241,7 +241,7 @@ let test_good_bad_server () =
       { Server.address = public_address; zones = Domain.Set.empty; timeout_ms = Some 1000; order = 0 };
       { Server.address = bad_address; zones = Domain.Set.empty; timeout_ms = Some 1000; order = 0 };
     ] in
-    let config = { servers; search = [] } in
+    let config = { servers; search = []; assume_offline_after_drops = None } in
     let open Lwt.Infix in
     R.create config
     >>= fun r ->
@@ -297,7 +297,7 @@ let test_bad_server () =
       { Server.address = public_address; zones = Domain.Set.empty; timeout_ms = Some 1000; order = 0 };
       { Server.address = bad_address; zones = Domain.Set.empty; timeout_ms = Some 1000; order = 0 };
     ] in
-    let config = { servers; search = [] } in
+    let config = { servers; search = []; assume_offline_after_drops = None } in
     let open Lwt.Infix in
     R.create config
     >>= fun r ->
@@ -342,7 +342,7 @@ let test_timeout () =
     let servers = Server.Set.of_list [
       { Server.address = bar_address; zones = Domain.Set.empty; timeout_ms = Some 0; order = 0 }
     ] in
-    let config = { servers; search = [] } in
+    let config = { servers; search = []; assume_offline_after_drops = None } in
     let open Lwt.Infix in
     R.create config
     >>= fun r ->
@@ -389,7 +389,7 @@ let test_cache () =
     let servers = Server.Set.of_list [
       { Server.address = bar_address; zones = Domain.Set.empty; timeout_ms = Some 1000; order = 0 }
     ] in
-    let config = { servers; search = [] } in
+    let config = { servers; search = []; assume_offline_after_drops = None } in
     let open Lwt.Infix in
     R.create config
     >>= fun r ->
@@ -445,7 +445,7 @@ let test_order () =
       { Server.address = public_address; zones = Domain.Set.empty; timeout_ms = None; order = 1 };
       { Server.address = private_address; zones = Domain.Set.empty; timeout_ms = None; order = 0 }
     ] in
-    let config = { servers; search = [] } in
+    let config = { servers; search = []; assume_offline_after_drops = None } in
     let open Lwt.Infix in
     R.create config
     >>= fun r ->
@@ -495,7 +495,7 @@ let test_forwarder_zone () =
       { Server.address = foo_address; zones = Domain.Set.add [ "foo" ] Domain.Set.empty; timeout_ms = None; order = 0 };
       { Server.address = bar_address; zones = Domain.Set.empty; timeout_ms = None; order = 0 }
     ] in
-    let config = { servers; search = [] } in
+    let config = { servers; search = []; assume_offline_after_drops = None } in
     let open Lwt.Infix in
     R.create config
     >>= fun r ->
@@ -555,12 +555,12 @@ let config_examples = [
   { servers = Server.Set.of_list [
     { Server.address = { Address.ip = Ipaddr.V4 (Ipaddr.V4.of_string_exn "10.0.0.2"); port = 53 }; zones = Domain.Set.empty; timeout_ms = None; order = 0 };
     { Server.address = { Address.ip = Ipaddr.V4 (Ipaddr.V4.of_string_exn "1.2.3.4"); port = 54 }; zones = Domain.Set.empty; timeout_ms = None; order = 0 };
-    ]; search = [ "a"; "b"; "c" ]
+    ]; search = [ "a"; "b"; "c" ]; assume_offline_after_drops = None
   };
   "nameserver 10.0.0.2\n",
   { servers = Server.Set.of_list [
     { Server.address = { Address.ip = Ipaddr.V4 (Ipaddr.V4.of_string_exn "10.0.0.2"); port = 53 }; zones = Domain.Set.empty; timeout_ms = None; order = 0 };
-    ]; search = []
+    ]; search = []; assume_offline_after_drops = None
   };
   String.concat "\n" [
     "# a pretend VPN zone with a private nameserver";
@@ -579,7 +579,7 @@ let config_examples = [
         timeout_ms = Some 5000;
         order = 1;
       };
-    ]; search = [];
+    ]; search = []; assume_offline_after_drops = None;
   };
 ]
 

--- a/lib_test/test.ml
+++ b/lib_test/test.ml
@@ -1,5 +1,6 @@
 
 module Error = Dns_forward.Error.Infix
+module Clock = Dns_forward_lwt_unix.Clock
 
 let fresh_id =
   let next = ref 1000 in
@@ -87,7 +88,7 @@ let test_local_lookups () =
     let open Error in
     S.serve ~address:public_address public_server
     >>= fun _ ->
-    let module R = Dns_forward.Resolver.Make(Rpc)(Time) in
+    let module R = Dns_forward.Resolver.Make(Rpc)(Time)(Clock) in
     let open Dns_forward.Config in
     let servers = Server.Set.of_list [
       { Server.address = public_address; zones = Domain.Set.empty; timeout_ms = None; order = 0 };
@@ -144,7 +145,7 @@ let test_tcp_multiplexing () =
     let open Error in
     S.serve ~address:public_address public_server
     >>= fun _ ->
-    let module R = Dns_forward.Resolver.Make(Proto_client)(Time) in
+    let module R = Dns_forward.Resolver.Make(Proto_client)(Time)(Clock) in
     let open Dns_forward.Config in
     let servers = Server.Set.of_list [
       { Server.address = public_address; zones = Domain.Set.empty; timeout_ms = None; order = 0 };
@@ -231,7 +232,7 @@ let test_good_bad_server () =
     let bad_address = { Dns_forward.Config.Address.ip = Ipaddr.V4 Ipaddr.V4.localhost; port = 999 } in
     S.serve ~address:bad_address bad_server
     >>= fun _ ->
-    let module R = Dns_forward.Resolver.Make(Proto_client)(Time) in
+    let module R = Dns_forward.Resolver.Make(Proto_client)(Time)(Clock) in
     let open Dns_forward.Config in
     (* Forward to a good server and a bad server, both with timeouts. The request to
        the bad request should fail fast but the good server should be given up to
@@ -286,7 +287,7 @@ let test_bad_server () =
     let open Error in
     S.serve ~address:public_address public_server
     >>= fun _ ->
-    let module R = Dns_forward.Resolver.Make(Proto_client)(Time) in
+    let module R = Dns_forward.Resolver.Make(Proto_client)(Time)(Clock) in
     let open Dns_forward.Config in
     let bad_address = { Dns_forward.Config.Address.ip = Ipaddr.V4 Ipaddr.V4.localhost; port = 999 } in
     (* Forward to a good server and a bad server, both with timeouts. The request to
@@ -336,7 +337,7 @@ let test_timeout () =
     S.serve ~address:bar_address bar_server
     >>= fun _ ->
     (* a resolver which uses both servers *)
-    let module R = Dns_forward.Resolver.Make(Proto_client)(Time) in
+    let module R = Dns_forward.Resolver.Make(Proto_client)(Time)(Clock) in
     let open Dns_forward.Config in
     let servers = Server.Set.of_list [
       { Server.address = bar_address; zones = Domain.Set.empty; timeout_ms = Some 0; order = 0 }
@@ -383,7 +384,7 @@ let test_cache () =
     S.serve ~address:bar_address bar_server
     >>= fun server ->
     (* a resolver which uses both servers *)
-    let module R = Dns_forward.Resolver.Make(Proto_client)(Time) in
+    let module R = Dns_forward.Resolver.Make(Proto_client)(Time)(Clock) in
     let open Dns_forward.Config in
     let servers = Server.Set.of_list [
       { Server.address = bar_address; zones = Domain.Set.empty; timeout_ms = Some 1000; order = 0 }
@@ -438,7 +439,7 @@ let test_order () =
     >>= fun _ ->
 
     (* a resolver which uses both servers *)
-    let module R = Dns_forward.Resolver.Make(Proto_client)(Time) in
+    let module R = Dns_forward.Resolver.Make(Proto_client)(Time)(Clock) in
     let open Dns_forward.Config in
     let servers = Server.Set.of_list [
       { Server.address = public_address; zones = Domain.Set.empty; timeout_ms = None; order = 1 };
@@ -488,7 +489,7 @@ let test_forwarder_zone () =
     S.serve ~address:bar_address bar_server
     >>= fun _ ->
     (* a resolver which uses both servers *)
-    let module R = Dns_forward.Resolver.Make(Rpc)(Time) in
+    let module R = Dns_forward.Resolver.Make(Rpc)(Time)(Clock) in
     let open Dns_forward.Config in
     let servers = Server.Set.of_list [
       { Server.address = foo_address; zones = Domain.Set.add [ "foo" ] Domain.Set.empty; timeout_ms = None; order = 0 };

--- a/pkg/META
+++ b/pkg/META
@@ -1,5 +1,5 @@
 description = "A DNS forwarding library"
-version = "0.8.1"
+version = "0.8.2"
 requires = "lwt logs fmt astring rresult cstruct mirage-flow channel mtime sexplib ipaddr dns"
 archive(byte) = "dns-forward.cma"
 archive(native) = "dns-forward.cmxa"
@@ -9,7 +9,7 @@ exists_if = "dns-forward.cma"
 
 package "lwt-unix" (
  description = "Lwt_unix I/O library"
- version = "0.8.1"
+ version = "0.8.2"
  requires = "io-page.unix dns-forward lwt.unix lwt logs rresult cstruct cstruct.lwt ipaddr"
  archive(byte) = "dns-forward-lwt-unix.cma"
  archive(native) = "dns-forward-lwt-unix.cmxa"


### PR DESCRIPTION
- add global configuration option `assume-offline-after-drops` which tells the resolver to consider an upstream offline if it fails to respond to this number of queries in a row
- when a server is offline we continue to send queries to it, but we don't wait for responses. This prevents a bad server making us wait until timeout on every request.
- we use `Lwt.nchoose_split` to wait for equal-priority results at once: this avoids waiting for requests in arbitrary list order (previously we used `Lwt.fold_left_s`)
- we resend requests every 1s even if the timeout is longer