### PR TITLE
Add .merlin and .ocp-indent

### DIFF
--- a/.merlin
+++ b/.merlin
@@ -1,0 +1,6 @@
+S lib/**
+S lib_test/**
+B _build/**
+
+PKG bytes lwt astring logs result cstruct fmt rresult ipaddr
+PKG dns mirage-flow cstruct.lwt channel mirage-types io-page.unix

--- a/.ocp-indent
+++ b/.ocp-indent
@@ -1,0 +1,1 @@
+strict_with=always,match_clause=4,strict_else=never


### PR DESCRIPTION
This is @dave-tucker's patch from #60 (unfortunately the `cop-indent` run has bit-rotted)

Signed-off-by: Dave Tucker <dave@dtucker.co.uk>