### PR TITLE
If no response is received, don't send a response

### DIFF
--- a/lib/dns_forward_resolver.ml
+++ b/lib/dns_forward_resolver.ml
@@ -135,13 +135,6 @@ module Make(Client: Dns_forward_s.RPC_CLIENT)(Time: V1_LWT.TIME)(Clock: V1.CLOCK
         let authorities = [] and additionals = [] in
         { id; detail; questions; answers; authorities; additionals } in
 
-      let nxdomain =
-        let id = request.id in
-        let detail = { request.detail with Dns.Packet.qr = Dns.Packet.Response; ra = true; rcode = Dns.Packet.NXDomain } in
-        let questions = request.questions in
-        let authorities = [] and additionals = [] and answers = [] in
-        { id; detail; questions; answers; authorities; additionals } in
-
       (* Look for any local answers to this question *)
       begin
         t.local_names_cb question
@@ -288,7 +281,7 @@ module Make(Client: Dns_forward_s.RPC_CLIENT)(Time: V1_LWT.TIME)(Clock: V1.CLOCK
             (fun best_so_far next -> match best_so_far with
               | Ok (`Success result) -> Lwt.return (Ok (`Success result))
               | best_so_far -> wait best_so_far next
-            ) (Ok (`Failure (Some nxdomain, marshal nxdomain))) online_results
+            )  (Error (`Msg "no servers configured")) online_results
           >>= function
           | Ok (`Success reply) -> Lwt_result.return reply
           | Ok (`Failure (_, reply)) -> Lwt_result.return reply

--- a/lib_test/test.ml
+++ b/lib_test/test.ml
@@ -430,11 +430,8 @@ let test_timeout () =
     let request =
       R.answer request r
       >>= function
-      | Result.Ok response ->
-        let open Dns.Packet in
-        let pkt = parse (Cstruct.to_bigarray response) in
-        Lwt.return (pkt.detail.rcode = NXDomain)
-      | Result.Error _ -> failwith "timeout test failed" in
+      | Result.Error _ -> Lwt.return true
+      | Result.Ok _ -> failwith "got a result when timeout expected" in
     let timeout =
       Lwt_unix.sleep 5.
       >>= fun () ->


### PR DESCRIPTION
Previously in d2566ce2 we changed the policy so that if there are
no servers or if they all timeout, we would send an NXDomain. This
patch reverts the change: on timeout, we will send no reply. This
ensures that we behave the same as the upstream server(s).

Signed-off-by: David Scott <dave.scott@docker.com>